### PR TITLE
Implement Yahoo OAuth flow with token refresh

### DIFF
--- a/apps/api/alembic/versions/002_make_user_email_nullable.py
+++ b/apps/api/alembic/versions/002_make_user_email_nullable.py
@@ -1,0 +1,21 @@
+"""Make user email nullable
+
+Revision ID: 002
+Revises: 001
+Create Date: 2023-01-01 06:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '002'
+down_revision = '001'
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    op.alter_column('users', 'email', existing_type=sa.String(), nullable=True)
+
+def downgrade() -> None:
+    op.alter_column('users', 'email', existing_type=sa.String(), nullable=False)

--- a/apps/api/app/deps.py
+++ b/apps/api/app/deps.py
@@ -1,6 +1,7 @@
 from fastapi import Depends, HTTPException, Header, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-from sqlalchemy.orm import Session
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
 from jose import JWTError, jwt
 from typing import Optional
 from .models import User
@@ -10,17 +11,24 @@ from .settings import settings
 # Security
 security = HTTPBearer()
 
+engine = create_engine(settings.database_url)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
 def get_db():
-    # This would normally come from a session manager
-    # For now, we'll implement a placeholder
-    pass
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
 
 def get_token_encryption_service():
     return TokenEncryptionService(settings.token_crypto_key)
 
+
 def get_current_user(
-    credentials: HTTPAuthorizationCredentials = Depends(security),
-    db: Session = Depends(get_db)
+    credentials: HTTPAuthorizationCredentials = Depends(security), db: Session = Depends(get_db)
 ) -> User:
     """Get the current authenticated user from JWT token"""
     credentials_exception = HTTPException(
@@ -28,40 +36,37 @@ def get_current_user(
         detail="Could not validate credentials",
         headers={"WWW-Authenticate": "Bearer"},
     )
-    
+
     try:
         # Decode the JWT token
-        payload = jwt.decode(
-            credentials.credentials,
-            settings.jwt_secret,
-            algorithms=["HS256"]
-        )
+        payload = jwt.decode(credentials.credentials, settings.jwt_secret, algorithms=["HS256"])
         user_id: int = payload.get("sub")
         if user_id is None:
             raise credentials_exception
     except JWTError:
         raise credentials_exception
-    
+
     # In a real implementation, we would fetch the user from the database
     # For now, we'll return a placeholder
     return User(id=user_id, email="user@example.com")
 
+
 def get_current_user_optional(
     credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
 ) -> Optional[User]:
     """Get the current authenticated user from JWT token, return None if not authenticated"""
     if credentials is None:
         return None
-    
+
     try:
         return get_current_user(credentials, db)
     except HTTPException:
         return None
 
+
 def get_debug_user(
-    debug_user: Optional[str] = Header(None, alias="X-Debug-User"),
-    db: Session = Depends(get_db)
+    debug_user: Optional[str] = Header(None, alias="X-Debug-User"), db: Session = Depends(get_db)
 ) -> Optional[User]:
     """Get user via debug header if enabled"""
     if not settings.allow_debug_user or not debug_user:

--- a/apps/api/app/models.py
+++ b/apps/api/app/models.py
@@ -1,24 +1,24 @@
-from sqlalchemy import Boolean, Column, Integer, String, DateTime, ForeignKey, Text, func
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Text, func
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
-from sqlalchemy.dialects.postgresql import UUID
-import uuid
 
 Base = declarative_base()
 
+
 class User(Base):
     __tablename__ = "users"
-    
+
     id = Column(Integer, primary_key=True, index=True)
-    email = Column(String, unique=True, index=True, nullable=False)
+    email = Column(String, unique=True, index=True, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
-    
+
     # Relationships
     oauth_tokens = relationship("OAuthToken", back_populates="user")
 
+
 class OAuthToken(Base):
     __tablename__ = "oauth_tokens"
-    
+
     id = Column(Integer, primary_key=True, index=True)
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     provider = Column(String, nullable=False)  # e.g., "yahoo"
@@ -27,6 +27,6 @@ class OAuthToken(Base):
     expires_at = Column(DateTime(timezone=True))
     scope = Column(Text)
     guid = Column(String, unique=True, index=True)  # Yahoo-specific GUID
-    
+
     # Relationships
     user = relationship("User", back_populates="oauth_tokens")

--- a/apps/api/app/routers/auth.py
+++ b/apps/api/app/routers/auth.py
@@ -1,41 +1,112 @@
-import base64, os
-from fastapi import APIRouter, Depends, Response
+import base64
+import os
+from datetime import datetime, timedelta
+from typing import Dict
+
+from fastapi import APIRouter, Depends, HTTPException, Response
+from fastapi.responses import RedirectResponse
+from sqlalchemy.orm import Session
+
 from ..settings import settings
-from ..deps import get_debug_user
+from ..deps import get_debug_user, get_db, get_token_encryption_service
 from ..session import SessionManager
-from ..models import User
+from ..models import User, OAuthToken
+from ..security import TokenEncryptionService
+from ..yahoo_oauth import YahooOAuthClient
 
 router = APIRouter()
 
 AUTH_URL = "https://api.login.yahoo.com/oauth2/request_auth"
-SCOPE = "fspt-r"
+SCOPE = "fspt-r openid profile email"
+state_store: Dict[str, datetime] = {}
+
 
 @router.get("/yahoo/login")
 def yahoo_login():
     state = base64.urlsafe_b64encode(os.urandom(16)).decode()
+    state_store[state] = datetime.utcnow()
     params = (
         f"client_id={settings.yahoo_client_id}&response_type=code&"
         f"redirect_uri={settings.yahoo_redirect_uri}&scope={SCOPE}&state={state}"
     )
     return {"redirect": f"{AUTH_URL}?{params}"}
 
+
 @router.get("/yahoo/callback")
-def yahoo_callback(code: str, state: str):
-    # Stub: exchange handled in later step
-    return {"received_code": code, "state": state}
+def yahoo_callback(
+    code: str,
+    state: str,
+    db: Session = Depends(get_db),
+    encryption: TokenEncryptionService = Depends(get_token_encryption_service),
+):
+    if state not in state_store:
+        raise HTTPException(status_code=400, detail="Invalid state")
+    state_store.pop(state, None)
+
+    client = YahooOAuthClient(encryption)
+    token_data = client.exchange_code(code)
+    access_token = token_data["access_token"]
+    refresh_token = token_data.get("refresh_token")
+    expires_in = token_data.get("expires_in", 0)
+    guid = token_data.get("xoauth_yahoo_guid")
+    scope = token_data.get("scope")
+    email = None
+    try:
+        userinfo = client.fetch_userinfo(access_token)
+        email = userinfo.get("email")
+    except Exception:
+        pass
+
+    user = None
+    if email:
+        user = db.query(User).filter_by(email=email).first()
+    if not user:
+        user = User(email=email)
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+
+    enc_access = encryption.encrypt(access_token)
+    enc_refresh = encryption.encrypt(refresh_token) if refresh_token else None
+    expires_at = datetime.utcnow() + timedelta(seconds=expires_in)
+
+    oauth = db.query(OAuthToken).filter_by(user_id=user.id, provider="yahoo").first()
+    if oauth:
+        oauth.access_token = enc_access
+        oauth.refresh_token = enc_refresh
+        oauth.expires_at = expires_at
+        oauth.scope = scope
+        oauth.guid = guid
+    else:
+        oauth = OAuthToken(
+            user_id=user.id,
+            provider="yahoo",
+            access_token=enc_access,
+            refresh_token=enc_refresh,
+            expires_at=expires_at,
+            scope=scope,
+            guid=guid,
+        )
+        db.add(oauth)
+    db.commit()
+
+    redirect = RedirectResponse(url="/leagues")
+    SessionManager.set_session_cookie(redirect, user.id)
+    return redirect
+
 
 @router.get("/session/debug", response_model=dict)
 def debug_session(
     response: Response,
-    current_user: User = Depends(get_debug_user)
+    current_user: User = Depends(get_debug_user),
 ):
     """Debug session endpoint - sets session cookie for dev user if enabled"""
     if not settings.allow_debug_user:
         return {"error": "Debug user not enabled"}
-    
+
     if current_user:
         # Set session cookie for the debug user
         SessionManager.set_session_cookie(response, current_user.id)
         return {"ok": True, "user_id": current_user.id}
-    
+
     return {"error": "Invalid debug user header"}

--- a/apps/api/app/yahoo_oauth.py
+++ b/apps/api/app/yahoo_oauth.py
@@ -1,0 +1,77 @@
+import base64
+import random
+import time
+from datetime import datetime, timedelta
+from typing import Dict
+
+import httpx
+from sqlalchemy.orm import Session
+
+from .models import OAuthToken
+from .security import TokenEncryptionService
+from .settings import settings
+
+TOKEN_URL = "https://api.login.yahoo.com/oauth2/get_token"
+USERINFO_URL = "https://api.login.yahoo.com/openid/v1/userinfo"
+
+
+class YahooOAuthClient:
+    """Client for handling Yahoo OAuth token exchange and refresh."""
+
+    def __init__(self, encryption: TokenEncryptionService):
+        auth = f"{settings.yahoo_client_id}:{settings.yahoo_client_secret}"
+        self.auth_header = base64.b64encode(auth.encode()).decode()
+        self.encryption = encryption
+
+    def _post(self, data: Dict[str, str]) -> Dict[str, str]:
+        headers = {
+            "Authorization": f"Basic {self.auth_header}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+        # basic retry with jitter
+        for attempt in range(3):
+            try:
+                response = httpx.post(TOKEN_URL, data=data, headers=headers, timeout=10)
+                response.raise_for_status()
+                return response.json()
+            except httpx.HTTPError:
+                if attempt == 2:
+                    raise
+                time.sleep(0.1 * (2**attempt) + random.random() / 10)
+        return {}
+
+    def exchange_code(self, code: str) -> Dict[str, str]:
+        data = {
+            "code": code,
+            "redirect_uri": settings.yahoo_redirect_uri,
+            "grant_type": "authorization_code",
+        }
+        return self._post(data)
+
+    def refresh_token(self, refresh_token: str) -> Dict[str, str]:
+        data = {
+            "refresh_token": refresh_token,
+            "redirect_uri": settings.yahoo_redirect_uri,
+            "grant_type": "refresh_token",
+        }
+        return self._post(data)
+
+    def fetch_userinfo(self, access_token: str) -> Dict[str, str]:
+        headers = {"Authorization": f"Bearer {access_token}"}
+        response = httpx.get(USERINFO_URL, headers=headers, timeout=10)
+        response.raise_for_status()
+        return response.json()
+
+    def ensure_valid_token(self, db: Session, token: OAuthToken) -> str:
+        """Return decrypted access token, refreshing if expiring soon."""
+        if token.expires_at and token.expires_at - datetime.utcnow() < timedelta(minutes=5):
+            data = self.refresh_token(self.encryption.decrypt(token.refresh_token))
+            token.access_token = self.encryption.encrypt(data["access_token"])
+            if data.get("refresh_token"):
+                token.refresh_token = self.encryption.encrypt(data["refresh_token"])
+            token.expires_at = datetime.utcnow() + timedelta(seconds=data.get("expires_in", 0))
+            token.scope = data.get("scope")
+            db.add(token)
+            db.commit()
+            db.refresh(token)
+        return self.encryption.decrypt(token.access_token)

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -16,3 +16,4 @@ alembic>=1.12
 python-jose[cryptography]>=3.3
 passlib[bcrypt]>=1.7.4
 httpx>=0.28
+respx>=0.20

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -1,0 +1,48 @@
+import pytest
+import os
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+os.environ["DATABASE_URL"] = "sqlite://"
+
+from app.main import app
+from app.models import Base
+from app.deps import get_db
+
+# In-memory SQLite database shared across threads
+engine = create_engine(
+    "sqlite://",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base.metadata.create_all(bind=engine)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = override_get_db
+
+
+@pytest.fixture()
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture()
+def db_session():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/apps/api/tests/test_oauth.py
+++ b/apps/api/tests/test_oauth.py
@@ -1,0 +1,80 @@
+from datetime import datetime, timedelta
+
+import respx
+
+from app.models import OAuthToken, User
+from app.security import TokenEncryptionService
+from app.settings import settings
+from app.yahoo_oauth import YahooOAuthClient
+from app.session import SessionManager
+
+
+def test_yahoo_login_and_callback_flow(client, db_session):
+    with respx.mock() as mock:
+        token_json = {
+            "access_token": "atoken",
+            "refresh_token": "rtoken",
+            "expires_in": 3600,
+            "scope": "fspt-r",
+            "xoauth_yahoo_guid": "ABC123",
+        }
+        mock.post("https://api.login.yahoo.com/oauth2/get_token").respond(200, json=token_json)
+        mock.get("https://api.login.yahoo.com/openid/v1/userinfo").respond(
+            200, json={"email": "user@example.com"}
+        )
+
+        login_resp = client.get("/auth/yahoo/login")
+        state = login_resp.json()["redirect"].split("state=")[-1]
+
+        resp = client.get(
+            "/auth/yahoo/callback",
+            params={"code": "123", "state": state},
+            follow_redirects=False,
+        )
+
+    assert resp.status_code in (302, 307)
+    assert SessionManager.COOKIE_NAME in resp.headers.get("set-cookie", "")
+    assert resp.headers["location"].endswith("/leagues")
+
+    token = db_session.query(OAuthToken).first()
+    assert token is not None
+    enc = TokenEncryptionService(settings.token_crypto_key)
+    assert enc.decrypt(token.access_token) == "atoken"
+
+
+def test_state_mismatch_returns_error(client):
+    resp = client.get("/auth/yahoo/callback", params={"code": "abc", "state": "bad"})
+    assert resp.status_code == 400
+
+
+def test_refresh_token_if_expiring(db_session):
+    enc = TokenEncryptionService(settings.token_crypto_key)
+    user = User(email=None)
+    db_session.add(user)
+    db_session.commit()
+    token = OAuthToken(
+        user_id=user.id,
+        provider="yahoo",
+        access_token=enc.encrypt("old"),
+        refresh_token=enc.encrypt("refresh"),
+        expires_at=datetime.utcnow() + timedelta(minutes=4),
+    )
+    db_session.add(token)
+    db_session.commit()
+
+    with respx.mock() as mock:
+        mock.post("https://api.login.yahoo.com/oauth2/get_token").respond(
+            200,
+            json={
+                "access_token": "new",
+                "refresh_token": "newrefresh",
+                "expires_in": 3600,
+                "scope": "fspt-r",
+                "xoauth_yahoo_guid": "ABC123",
+            },
+        )
+        client_obj = YahooOAuthClient(enc)
+        access = client_obj.ensure_valid_token(db_session, token)
+
+    assert access == "new"
+    assert enc.decrypt(token.access_token) == "new"

--- a/docs/IMPLEMENTATION_AND_STATUS_REPORT.md
+++ b/docs/IMPLEMENTATION_AND_STATUS_REPORT.md
@@ -122,14 +122,29 @@
 
 ---
 
+## Phase 2 — Yahoo OAuth 3-Legged Flow
+
+### Status: ✅ COMPLETED
+
+### Changes Made
+- Implemented full Yahoo OAuth login and callback endpoints with state verification and cookie-based sessions.
+- Added `YahooOAuthClient` handling token exchange, refresh with jittered retries, and userinfo retrieval.
+- Persisted encrypted access and refresh tokens tied to users; created new migration allowing nullable emails.
+- Wired database session dependency and introduced unit tests for OAuth flow and token refresh.
+
+### Outstanding Issues
+- None
+
+---
+
 ## Overall Status
 
 ### Completed Tasks
 - Phase 0: ✅ Infra & CI Skeleton
 - Phase 1: ✅ Auth Foundations
+- Phase 2: ✅ Yahoo OAuth
 
 ### Upcoming Phases
-- Phase 2: OAuth Integration (Yahoo)
 - Phase 3: User Management
 - Phase 4: Fantasy Data Integration
 - Phase 5: Optimization Engine


### PR DESCRIPTION
## Summary
- add Yahoo OAuth login/callback endpoints with session cookie
- persist encrypted Yahoo tokens and auto-refresh when near expiry
- document Phase 2 completion and add OAuth tests

## Testing
- `ruff check app/routers/auth.py app/deps.py app/models.py app/yahoo_oauth.py tests/test_oauth.py tests/conftest.py`
- `black --check app/routers/auth.py app/deps.py app/models.py app/yahoo_oauth.py tests/test_oauth.py tests/conftest.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5849d9b6c83239ced175f9e28e082