### PR TITLE
feat: yahoo league read endpoints

### DIFF
--- a/apps/api/alembic/env.py
+++ b/apps/api/alembic/env.py
@@ -16,7 +16,9 @@ if config.config_file_name is not None:
 
 # add your model's MetaData object here
 # for 'autogenerate' support
-from app.models import Base
+# isort: off
+from app.models import Base  # noqa: E402
+
 target_metadata = Base.metadata
 
 # other values from the config, defined by the needs of env.py,
@@ -63,9 +65,7 @@ def run_migrations_online() -> None:
     )
 
     with connectable.connect() as connection:
-        context.configure(
-            connection=connection, target_metadata=target_metadata
-        )
+        context.configure(connection=connection, target_metadata=target_metadata)
 
         with context.begin_transaction():
             context.run_migrations()

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -1,16 +1,15 @@
-from fastapi import FastAPI, Depends
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from sqlalchemy.orm import Session
-from .settings import settings
 from .routers import health, auth, yahoo, optimize
-from .deps import get_db
 
 app = FastAPI(title="Fantasy Edge API")
 
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["http://localhost:3000", "https://misfits.westfam.media"],
-    allow_credentials=True, allow_methods=["*"], allow_headers=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 app.include_router(health.router)

--- a/apps/api/app/routers/yahoo.py
+++ b/apps/api/app/routers/yahoo.py
@@ -1,8 +1,80 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from ..deps import get_db, get_current_user_session, get_yahoo_client
+from ..models import User
+from ..yahoo_client import YahooFantasyClient
 
 router = APIRouter()
 
+
+def _scoring_map(data):
+    scoring = {}
+    try:
+        league = data.get("fantasy_content", {}).get("league")
+        if isinstance(league, list):
+            league = league[1]
+        stats = league.get("settings", {}).get("stat_categories", {}).get("stats", [])
+        for stat in stats:
+            st = stat.get("stat", {})
+            sid = st.get("stat_id")
+            name = st.get("display_name") or st.get("name")
+            if sid is not None and name:
+                scoring[str(sid)] = name
+    except Exception:
+        pass
+    return scoring
+
+
 @router.get("/leagues")
-def list_leagues():
-    # Stub: will call Yahoo after OAuth is implemented
-    return {"leagues": []}
+def list_leagues(
+    current_user: User = Depends(get_current_user_session),
+    db: Session = Depends(get_db),
+    client: YahooFantasyClient = Depends(get_yahoo_client),
+):
+    return client.get(db, current_user, "/users;use_login=1/games;game_keys=nfl/leagues")
+
+
+@router.get("/league/{league_key}")
+def league_meta(
+    league_key: str,
+    current_user: User = Depends(get_current_user_session),
+    db: Session = Depends(get_db),
+    client: YahooFantasyClient = Depends(get_yahoo_client),
+):
+    data = client.get(db, current_user, f"/league/{league_key}")
+    return {"raw": data, "scoring": _scoring_map(data)}
+
+
+@router.get("/league/{league_key}/teams")
+def league_teams(
+    league_key: str,
+    current_user: User = Depends(get_current_user_session),
+    db: Session = Depends(get_db),
+    client: YahooFantasyClient = Depends(get_yahoo_client),
+):
+    return client.get(db, current_user, f"/league/{league_key}/teams")
+
+
+@router.get("/league/{league_key}/rosters")
+def league_rosters(
+    league_key: str,
+    week: int,
+    current_user: User = Depends(get_current_user_session),
+    db: Session = Depends(get_db),
+    client: YahooFantasyClient = Depends(get_yahoo_client),
+):
+    return client.get(db, current_user, f"/league/{league_key}/rosters", params={"week": str(week)})
+
+
+@router.get("/league/{league_key}/matchups")
+def league_matchups(
+    league_key: str,
+    week: int,
+    current_user: User = Depends(get_current_user_session),
+    db: Session = Depends(get_db),
+    client: YahooFantasyClient = Depends(get_yahoo_client),
+):
+    return client.get(
+        db, current_user, f"/league/{league_key}/matchups", params={"week": str(week)}
+    )

--- a/apps/api/app/security.py
+++ b/apps/api/app/security.py
@@ -1,6 +1,6 @@
 from cryptography.fernet import Fernet
-import os
 import base64
+
 
 class TokenEncryptionService:
     """Service for encrypting and decrypting OAuth tokens at rest"""

--- a/apps/api/app/yahoo_client.py
+++ b/apps/api/app/yahoo_client.py
@@ -1,0 +1,47 @@
+import random
+import time
+from typing import Optional, Dict
+
+import httpx
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from .models import OAuthToken, User
+from .yahoo_oauth import YahooOAuthClient
+
+
+class YahooFantasyClient:
+    """Minimal Yahoo Fantasy Sports API client."""
+
+    BASE_URL = "https://fantasysports.yahooapis.com/fantasy/v2"
+
+    def __init__(self, oauth_client: YahooOAuthClient):
+        self.oauth_client = oauth_client
+
+    def _request(
+        self, db: Session, user: User, resource: str, params: Optional[Dict[str, str]] = None
+    ) -> Dict:
+        token = db.query(OAuthToken).filter_by(user_id=user.id, provider="yahoo").first()
+        if not token:
+            raise HTTPException(status_code=401, detail="Yahoo token not found")
+        access = self.oauth_client.ensure_valid_token(db, token)
+        url = f"{self.BASE_URL}{resource}"
+        params = params or {}
+        params.setdefault("format", "json")
+        headers = {"Authorization": f"Bearer {access}"}
+        for attempt in range(3):
+            try:
+                resp = httpx.get(url, params=params, headers=headers, timeout=10)
+                resp.raise_for_status()
+                return resp.json()
+            except httpx.HTTPError:
+                if attempt == 2:
+                    raise
+                time.sleep(0.1 * (2**attempt) + random.random() / 10)
+        return {}
+
+    def get(
+        self, db: Session, user: User, resource: str, params: Optional[Dict[str, str]] = None
+    ) -> Dict:
+        """Public GET wrapper"""
+        return self._request(db, user, resource, params)

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -1,9 +1,8 @@
-import pytest
 from fastapi.testclient import TestClient
 from app.security import TokenEncryptionService
 from app.session import SessionManager
-from app.models import User
 from app.settings import settings
+
 
 # Test the token encryption service
 def test_token_encryption_roundtrip():
@@ -21,6 +20,7 @@ def test_token_encryption_roundtrip():
     decrypted = encryption_service.decrypt(encrypted)
     assert decrypted == test_token
 
+
 # Test session management
 def test_session_token_creation():
     # Create a test user ID
@@ -34,11 +34,13 @@ def test_session_token_creation():
     verified_user_id = SessionManager.verify_token(token)
     assert verified_user_id == user_id
 
+
 def test_session_token_invalid():
     # Test with an invalid token
     invalid_token = "invalid.token.here"
     verified_user_id = SessionManager.verify_token(invalid_token)
     assert verified_user_id is None
+
 
 # Test debug bypass functionality
 def test_debug_bypass_disabled():
@@ -48,6 +50,7 @@ def test_debug_bypass_disabled():
 
     # Create a test client
     from app.main import app
+
     client = TestClient(app)
 
     # Try to access debug endpoint
@@ -58,6 +61,7 @@ def test_debug_bypass_disabled():
     # Restore original value
     settings.allow_debug_user = original_value
 
+
 def test_debug_bypass_enabled():
     # Temporarily enable debug user
     original_value = settings.allow_debug_user
@@ -65,6 +69,7 @@ def test_debug_bypass_enabled():
 
     # Create a test client
     from app.main import app
+
     client = TestClient(app)
 
     # Try to access debug endpoint
@@ -80,6 +85,7 @@ def test_debug_bypass_enabled():
     # Restore original value
     settings.allow_debug_user = original_value
 
+
 def test_debug_bypass_invalid_header():
     # Temporarily enable debug user
     original_value = settings.allow_debug_user
@@ -87,6 +93,7 @@ def test_debug_bypass_invalid_header():
 
     # Create a test client
     from app.main import app
+
     client = TestClient(app)
 
     # Try to access debug endpoint with invalid header

--- a/apps/api/tests/test_yahoo.py
+++ b/apps/api/tests/test_yahoo.py
@@ -1,0 +1,124 @@
+from datetime import datetime, timedelta
+
+import respx
+
+from app.models import User, OAuthToken
+from app.security import TokenEncryptionService
+from app.settings import settings
+
+
+def _setup_user(db_session):
+    user = User(email=None)
+    db_session.add(user)
+    db_session.commit()
+    enc = TokenEncryptionService(settings.token_crypto_key)
+    token = OAuthToken(
+        user_id=user.id,
+        provider="yahoo",
+        access_token=enc.encrypt("old"),
+        refresh_token=enc.encrypt("refresh"),
+        expires_at=datetime.utcnow() + timedelta(hours=1),
+    )
+    db_session.add(token)
+    db_session.commit()
+    return user, token, enc
+
+
+def _auth_client(client, user):
+    original = settings.allow_debug_user
+    settings.allow_debug_user = True
+    client.get("/auth/session/debug", headers={"X-Debug-User": str(user.id)})
+    settings.allow_debug_user = original
+
+
+def test_requires_auth(client):
+    resp = client.get("/yahoo/leagues")
+    assert resp.status_code == 401
+
+
+def test_list_leagues(client, db_session):
+    user, token, enc = _setup_user(db_session)
+    _auth_client(client, user)
+    with respx.mock() as mock:
+        mock.get(
+            "https://fantasysports.yahooapis.com/fantasy/v2/users;use_login=1/games;game_keys=nfl/leagues",
+            params={"format": "json"},
+        ).respond(200, json={"fantasy_content": {"leagues": []}})
+        resp = client.get("/yahoo/leagues")
+    assert resp.status_code == 200
+    assert resp.json()["fantasy_content"]["leagues"] == []
+
+
+def test_league_meta_scoring(client, db_session):
+    user, token, enc = _setup_user(db_session)
+    _auth_client(client, user)
+    league_json = {
+        "fantasy_content": {
+            "league": {
+                "settings": {
+                    "stat_categories": {"stats": [{"stat": {"stat_id": 1, "name": "Points"}}]}
+                }
+            }
+        }
+    }
+    with respx.mock() as mock:
+        mock.get(
+            "https://fantasysports.yahooapis.com/fantasy/v2/league/123",
+            params={"format": "json"},
+        ).respond(200, json=league_json)
+        resp = client.get("/yahoo/league/123")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["raw"] == league_json
+    assert body["scoring"] == {"1": "Points"}
+
+
+def test_league_teams_rosters_matchups(client, db_session):
+    user, token, enc = _setup_user(db_session)
+    _auth_client(client, user)
+    with respx.mock() as mock:
+        mock.get(
+            "https://fantasysports.yahooapis.com/fantasy/v2/league/123/teams",
+            params={"format": "json"},
+        ).respond(200, json={"teams": []})
+        mock.get(
+            "https://fantasysports.yahooapis.com/fantasy/v2/league/123/rosters",
+            params={"format": "json", "week": "5"},
+        ).respond(200, json={"rosters": []})
+        mock.get(
+            "https://fantasysports.yahooapis.com/fantasy/v2/league/123/matchups",
+            params={"format": "json", "week": "5"},
+        ).respond(200, json={"matchups": []})
+        teams = client.get("/yahoo/league/123/teams")
+        rosters = client.get("/yahoo/league/123/rosters", params={"week": 5})
+        matchups = client.get("/yahoo/league/123/matchups", params={"week": 5})
+    assert teams.status_code == 200 and teams.json() == {"teams": []}
+    assert rosters.status_code == 200 and rosters.json() == {"rosters": []}
+    assert matchups.status_code == 200 and matchups.json() == {"matchups": []}
+
+
+def test_refresh_path(client, db_session):
+    user, token, enc = _setup_user(db_session)
+    token.expires_at = datetime.utcnow() + timedelta(minutes=4)
+    db_session.add(token)
+    db_session.commit()
+    _auth_client(client, user)
+    with respx.mock() as mock:
+        mock.post("https://api.login.yahoo.com/oauth2/get_token").respond(
+            200,
+            json={
+                "access_token": "new",
+                "refresh_token": "newrefresh",
+                "expires_in": 3600,
+                "scope": "fspt-r",
+                "xoauth_yahoo_guid": "ABC123",
+            },
+        )
+        mock.get(
+            "https://fantasysports.yahooapis.com/fantasy/v2/users;use_login=1/games;game_keys=nfl/leagues",
+            params={"format": "json"},
+        ).respond(200, json={"fantasy_content": {}})
+        resp = client.get("/yahoo/leagues")
+    assert resp.status_code == 200
+    db_session.refresh(token)
+    assert enc.decrypt(token.access_token) == "new"

--- a/docs/IMPLEMENTATION_AND_STATUS_REPORT.md
+++ b/docs/IMPLEMENTATION_AND_STATUS_REPORT.md
@@ -137,15 +137,34 @@
 
 ---
 
+## Phase 3 — Yahoo League Read Endpoints
+
+### Status: ✅ COMPLETED
+
+### Changes Made
+- Implemented `YahooFantasyClient` with automatic token refresh and retry logic.
+- Added session-based user dependency and Yahoo read endpoints:
+  - `/yahoo/leagues`
+  - `/yahoo/league/{league_key}` (includes normalized scoring map skeleton)
+  - `/yahoo/league/{league_key}/teams`
+  - `/yahoo/league/{league_key}/rosters?week=N`
+  - `/yahoo/league/{league_key}/matchups?week=N`
+- Added tests mocking Yahoo HTTP responses, auth guard, and token refresh path.
+
+### Outstanding Issues
+- None
+
+---
+
 ## Overall Status
 
 ### Completed Tasks
 - Phase 0: ✅ Infra & CI Skeleton
 - Phase 1: ✅ Auth Foundations
 - Phase 2: ✅ Yahoo OAuth
+- Phase 3: ✅ Yahoo League Read Endpoints
 
 ### Upcoming Phases
-- Phase 3: User Management
 - Phase 4: Fantasy Data Integration
 - Phase 5: Optimization Engine
 


### PR DESCRIPTION
## Summary
- add YahooFantasyClient with token refresh and retries
- expose league, team, roster, and matchup read endpoints
- document Phase 3 completion in implementation report

## Testing
- `ruff check .`
- `black --check app/main.py app/security.py app/routers/yahoo.py app/yahoo_client.py tests/test_auth.py tests/test_yahoo.py alembic/env.py`
- `mypy --ignore-missing-imports --explicit-package-bases app tests` *(fails: type errors in existing modules)*
- `pytest`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b588d890fc8323b2869be3aea25e64