### PR TITLE
feat(api): expand domain schema with seeding

### DIFF
--- a/apps/api/alembic/env.py
+++ b/apps/api/alembic/env.py
@@ -45,6 +45,7 @@ def run_migrations_offline() -> None:
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
+        **config.attributes.get("configure_args", {}),
     )
 
     with context.begin_transaction():
@@ -65,7 +66,11 @@ def run_migrations_online() -> None:
     )
 
     with connectable.connect() as connection:
-        context.configure(connection=connection, target_metadata=target_metadata)
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            **config.attributes.get("configure_args", {}),
+        )
 
         with context.begin_transaction():
             context.run_migrations()

--- a/apps/api/alembic/versions/003_add_domain_tables.py
+++ b/apps/api/alembic/versions/003_add_domain_tables.py
@@ -1,0 +1,160 @@
+"""Add domain tables
+
+Revision ID: 003
+Revises: 002
+Create Date: 2023-01-01 07:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '003'
+down_revision = '002'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'leagues',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('yahoo_id', sa.Integer(), nullable=False),
+        sa.Column('name', sa.String(), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('yahoo_id'),
+    )
+    op.create_index(op.f('ix_leagues_id'), 'leagues', ['id'], unique=False)
+    op.create_index(op.f('ix_leagues_yahoo_id'), 'leagues', ['yahoo_id'], unique=True)
+
+    op.create_table(
+        'teams',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('league_id', sa.Integer(), nullable=False),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('yahoo_id', sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(['league_id'], ['leagues.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(op.f('ix_teams_id'), 'teams', ['id'], unique=False)
+
+    op.create_table(
+        'players',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('position', sa.String(), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(op.f('ix_players_id'), 'players', ['id'], unique=False)
+
+    op.create_table(
+        'player_links',
+        sa.Column('player_id', sa.Integer(), nullable=False),
+        sa.Column('yahoo_key', sa.String(), nullable=True),
+        sa.Column('gsis_id', sa.String(), nullable=True),
+        sa.Column('pfr_id', sa.String(), nullable=True),
+        sa.Column('last_manual_override', sa.Boolean(), nullable=False, server_default=sa.text('false')),
+        sa.ForeignKeyConstraint(['player_id'], ['players.id']),
+        sa.PrimaryKeyConstraint('player_id'),
+        sa.UniqueConstraint('yahoo_key'),
+        sa.UniqueConstraint('gsis_id'),
+        sa.UniqueConstraint('pfr_id'),
+    )
+    op.create_index(op.f('ix_player_links_gsis_id'), 'player_links', ['gsis_id'], unique=True)
+    op.create_index(op.f('ix_player_links_pfr_id'), 'player_links', ['pfr_id'], unique=True)
+    op.create_index(op.f('ix_player_links_yahoo_key'), 'player_links', ['yahoo_key'], unique=True)
+
+    op.create_table(
+        'baselines',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('player_id', sa.Integer(), nullable=False),
+        sa.Column('metric', sa.String(), nullable=False),
+        sa.Column('value', sa.Float(), nullable=False),
+        sa.ForeignKeyConstraint(['player_id'], ['players.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(op.f('ix_baselines_id'), 'baselines', ['id'], unique=False)
+
+    op.create_table(
+        'injuries',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('player_id', sa.Integer(), nullable=False),
+        sa.Column('status', sa.String(), nullable=False),
+        sa.Column('report_time', sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(['player_id'], ['players.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(op.f('ix_injuries_id'), 'injuries', ['id'], unique=False)
+
+    op.create_table(
+        'projections',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('player_id', sa.Integer(), nullable=False),
+        sa.Column('week', sa.Integer(), nullable=False),
+        sa.Column('projected_points', sa.Float(), nullable=False),
+        sa.ForeignKeyConstraint(['player_id'], ['players.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(op.f('ix_projections_id'), 'projections', ['id'], unique=False)
+
+    op.create_table(
+        'recommendations',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('player_id', sa.Integer(), nullable=False),
+        sa.Column('recommendation', sa.String(), nullable=False),
+        sa.Column('reason', sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(['player_id'], ['players.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(op.f('ix_recommendations_id'), 'recommendations', ['id'], unique=False)
+
+    op.create_table(
+        'roster_slots',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('team_id', sa.Integer(), nullable=False),
+        sa.Column('player_id', sa.Integer(), nullable=False),
+        sa.Column('week', sa.Integer(), nullable=False),
+        sa.Column('position', sa.String(), nullable=True),
+        sa.ForeignKeyConstraint(['player_id'], ['players.id']),
+        sa.ForeignKeyConstraint(['team_id'], ['teams.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(op.f('ix_roster_slots_id'), 'roster_slots', ['id'], unique=False)
+
+    op.create_table(
+        'weather',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('game_id', sa.String(), nullable=False),
+        sa.Column('waf', sa.Float(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('game_id'),
+    )
+    op.create_index(op.f('ix_weather_game_id'), 'weather', ['game_id'], unique=True)
+    op.create_index(op.f('ix_weather_id'), 'weather', ['id'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_weather_id'), table_name='weather')
+    op.drop_index(op.f('ix_weather_game_id'), table_name='weather')
+    op.drop_table('weather')
+    op.drop_index(op.f('ix_roster_slots_id'), table_name='roster_slots')
+    op.drop_table('roster_slots')
+    op.drop_index(op.f('ix_recommendations_id'), table_name='recommendations')
+    op.drop_table('recommendations')
+    op.drop_index(op.f('ix_projections_id'), table_name='projections')
+    op.drop_table('projections')
+    op.drop_index(op.f('ix_injuries_id'), table_name='injuries')
+    op.drop_table('injuries')
+    op.drop_index(op.f('ix_baselines_id'), table_name='baselines')
+    op.drop_table('baselines')
+    op.drop_index(op.f('ix_player_links_yahoo_key'), table_name='player_links')
+    op.drop_index(op.f('ix_player_links_pfr_id'), table_name='player_links')
+    op.drop_index(op.f('ix_player_links_gsis_id'), table_name='player_links')
+    op.drop_table('player_links')
+    op.drop_index(op.f('ix_players_id'), table_name='players')
+    op.drop_table('players')
+    op.drop_index(op.f('ix_teams_id'), table_name='teams')
+    op.drop_table('teams')
+    op.drop_index(op.f('ix_leagues_yahoo_id'), table_name='leagues')
+    op.drop_index(op.f('ix_leagues_id'), table_name='leagues')
+    op.drop_table('leagues')

--- a/apps/api/app/models.py
+++ b/apps/api/app/models.py
@@ -1,4 +1,14 @@
-from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, Text, func
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    DateTime,
+    ForeignKey,
+    Text,
+    func,
+    Boolean,
+    Float,
+)
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
 
@@ -30,3 +40,117 @@ class OAuthToken(Base):
 
     # Relationships
     user = relationship("User", back_populates="oauth_tokens")
+
+
+class League(Base):
+    __tablename__ = "leagues"
+
+    id = Column(Integer, primary_key=True, index=True)
+    yahoo_id = Column(Integer, unique=True, nullable=False, index=True)
+    name = Column(String, nullable=True)
+
+    teams = relationship("Team", back_populates="league")
+
+
+class Team(Base):
+    __tablename__ = "teams"
+
+    id = Column(Integer, primary_key=True, index=True)
+    league_id = Column(Integer, ForeignKey("leagues.id"), nullable=False)
+    name = Column(String, nullable=False)
+    yahoo_id = Column(Integer, nullable=True)
+
+    league = relationship("League", back_populates="teams")
+    roster_slots = relationship("RosterSlot", back_populates="team")
+
+
+class Player(Base):
+    __tablename__ = "players"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    position = Column(String, nullable=True)
+
+    roster_slots = relationship("RosterSlot", back_populates="player")
+    injuries = relationship("Injury", back_populates="player")
+    baselines = relationship("Baseline", back_populates="player")
+    projections = relationship("Projection", back_populates="player")
+    recommendations = relationship("Recommendation", back_populates="player")
+    link = relationship("PlayerLink", back_populates="player", uselist=False)
+
+
+class RosterSlot(Base):
+    __tablename__ = "roster_slots"
+
+    id = Column(Integer, primary_key=True, index=True)
+    team_id = Column(Integer, ForeignKey("teams.id"), nullable=False)
+    player_id = Column(Integer, ForeignKey("players.id"), nullable=False)
+    week = Column(Integer, nullable=False)
+    position = Column(String, nullable=True)
+
+    team = relationship("Team", back_populates="roster_slots")
+    player = relationship("Player", back_populates="roster_slots")
+
+
+class Injury(Base):
+    __tablename__ = "injuries"
+
+    id = Column(Integer, primary_key=True, index=True)
+    player_id = Column(Integer, ForeignKey("players.id"), nullable=False)
+    status = Column(String, nullable=False)
+    report_time = Column(DateTime(timezone=True), nullable=False)
+
+    player = relationship("Player", back_populates="injuries")
+
+
+class Weather(Base):
+    __tablename__ = "weather"
+
+    id = Column(Integer, primary_key=True, index=True)
+    game_id = Column(String, unique=True, nullable=False, index=True)
+    waf = Column(Float, nullable=False)
+
+
+class Baseline(Base):
+    __tablename__ = "baselines"
+
+    id = Column(Integer, primary_key=True, index=True)
+    player_id = Column(Integer, ForeignKey("players.id"), nullable=False)
+    metric = Column(String, nullable=False)
+    value = Column(Float, nullable=False)
+
+    player = relationship("Player", back_populates="baselines")
+
+
+class Projection(Base):
+    __tablename__ = "projections"
+
+    id = Column(Integer, primary_key=True, index=True)
+    player_id = Column(Integer, ForeignKey("players.id"), nullable=False)
+    week = Column(Integer, nullable=False)
+    projected_points = Column(Float, nullable=False)
+
+    player = relationship("Player", back_populates="projections")
+
+
+class Recommendation(Base):
+    __tablename__ = "recommendations"
+
+    id = Column(Integer, primary_key=True, index=True)
+    player_id = Column(Integer, ForeignKey("players.id"), nullable=False)
+    recommendation = Column(String, nullable=False)
+    reason = Column(Text, nullable=True)
+
+    player = relationship("Player", back_populates="recommendations")
+
+
+class PlayerLink(Base):
+    __tablename__ = "player_links"
+
+    player_id = Column(Integer, ForeignKey("players.id"), primary_key=True)
+    yahoo_key = Column(String, unique=True, nullable=True, index=True)
+    gsis_id = Column(String, unique=True, nullable=True, index=True)
+    pfr_id = Column(String, unique=True, nullable=True, index=True)
+    last_manual_override = Column(Boolean, default=False, nullable=False)
+
+    player = relationship("Player", back_populates="link")

--- a/apps/api/app/seed.py
+++ b/apps/api/app/seed.py
@@ -1,0 +1,15 @@
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from .models import League
+
+
+def seed_league(db: Session, yahoo_id: int = 528886, name: str | None = None) -> League:
+    """Ensure a league row exists for the given Yahoo league id."""
+    league = db.execute(select(League).where(League.yahoo_id == yahoo_id)).scalar_one_or_none()
+    if league is None:
+        league = League(yahoo_id=yahoo_id, name=name or f"League {yahoo_id}")
+        db.add(league)
+        db.commit()
+        db.refresh(league)
+    return league

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 import os
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
@@ -17,6 +17,13 @@ engine = create_engine(
     connect_args={"check_same_thread": False},
     poolclass=StaticPool,
 )
+
+
+@event.listens_for(engine, "connect")
+def set_sqlite_pragma(dbapi_connection, connection_record):
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
 TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base.metadata.create_all(bind=engine)

--- a/apps/api/tests/test_db_schema.py
+++ b/apps/api/tests/test_db_schema.py
@@ -1,0 +1,43 @@
+import pytest
+from alembic import command
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from app.models import League, Team
+from app.seed import seed_league
+
+
+def test_migrations_upgrade(tmp_path):
+    cfg = Config("alembic.ini")
+    cfg.set_main_option("sqlalchemy.url", "sqlite://")
+    cfg.attributes["configure_args"] = {"render_as_batch": True}
+    command.upgrade(cfg, "head", sql=True)
+
+
+def test_foreign_key_integrity(db_session):
+    league = League(yahoo_id=1, name="Test")
+    db_session.add(league)
+    db_session.commit()
+    with pytest.raises(IntegrityError):
+        db_session.add(Team(league_id=999, name="Bad"))
+        db_session.commit()
+    db_session.rollback()
+
+
+def test_unique_constraint(db_session):
+    db_session.add(League(yahoo_id=2, name="A"))
+    db_session.commit()
+    db_session.add(League(yahoo_id=2, name="B"))
+    with pytest.raises(IntegrityError):
+        db_session.commit()
+    db_session.rollback()
+
+
+def test_seed_idempotent(db_session):
+    seed_league(db_session)
+    seed_league(db_session)
+    rows = db_session.execute(select(League).where(League.yahoo_id == 528886)).scalars().all()
+    assert len(rows) == 1

--- a/docs/IMPLEMENTATION_AND_STATUS_REPORT.md
+++ b/docs/IMPLEMENTATION_AND_STATUS_REPORT.md
@@ -156,6 +156,21 @@
 
 ---
 
+## Phase 4 — Database Schema Expansion & Seeding
+
+### Status: ✅ COMPLETED
+
+### Changes Made
+- Added SQLAlchemy models and Alembic migration for `league`, `team`, `player`, `roster_slot`, `injury`, `weather`, `baseline`, `projection`, `recommendation`, and `player_link` tables.
+- Implemented `seed_league` helper to insert league `528886` when missing.
+- Enabled SQLite foreign key enforcement in tests.
+- Created tests ensuring migrations run, foreign keys and unique constraints are enforced, and seeding is idempotent.
+
+### Outstanding Issues
+- None
+
+---
+
 ## Overall Status
 
 ### Completed Tasks
@@ -163,10 +178,11 @@
 - Phase 1: ✅ Auth Foundations
 - Phase 2: ✅ Yahoo OAuth
 - Phase 3: ✅ Yahoo League Read Endpoints
+- Phase 4: ✅ Database Schema Expansion & Seeding
 
 ### Upcoming Phases
-- Phase 4: Fantasy Data Integration
-- Phase 5: Optimization Engine
+- Phase 5: Free Data Integrations
+- Phase 6: Optimization Engine
 
 ### General Notes
 - All implementations follow security best practices


### PR DESCRIPTION
## Summary
- add league, team, player, roster, injury, weather, baseline, projection, recommendation, and player link models
- seed default league 528886 and wire Alembic migration for domain tables
- enforce foreign keys in tests and cover migration, constraint, and seed behavior

## Testing
- `cd apps/api && pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b58bb9fb3083238944443b59abb720