### PR TITLE
feat: add comprehensive scoring engine

### DIFF
--- a/docs/IMPLEMENTATION_AND_STATUS_REPORT.md
+++ b/docs/IMPLEMENTATION_AND_STATUS_REPORT.md
@@ -171,6 +171,20 @@
 
 ---
 
+## Phase 6 — Scoring Engine
+
+### Status: ✅ COMPLETED
+
+### Changes Made
+- Added pure scoring utilities for offense, kickers, defense/special teams, and individual defensive players.
+- Covered yardage bonuses, big-play extras, return yards, and turnover penalties.
+- Introduced golden tests with multiple statlines for each position to validate calculations.
+
+### Outstanding Issues
+- None
+
+---
+
 ## Overall Status
 
 ### Completed Tasks
@@ -179,10 +193,11 @@
 - Phase 2: ✅ Yahoo OAuth
 - Phase 3: ✅ Yahoo League Read Endpoints
 - Phase 4: ✅ Database Schema Expansion & Seeding
+- Phase 6: ✅ Scoring Engine
 
 ### Upcoming Phases
 - Phase 5: Free Data Integrations
-- Phase 6: Optimization Engine
+- Phase 7: Projection Pipeline
 
 ### General Notes
 - All implementations follow security best practices

--- a/packages/scoring/scoring/__init__.py
+++ b/packages/scoring/scoring/__init__.py
@@ -1,1 +1,21 @@
-from .league_scoring import Statline, offense_points
+from .league_scoring import (
+    OffenseStatline,
+    KickerStatline,
+    DefenseStatline,
+    IDPStatline,
+    offense_points,
+    kicker_points,
+    defense_points,
+    idp_points,
+)
+
+__all__ = [
+    "OffenseStatline",
+    "KickerStatline",
+    "DefenseStatline",
+    "IDPStatline",
+    "offense_points",
+    "kicker_points",
+    "defense_points",
+    "idp_points",
+]

--- a/packages/scoring/scoring/league_scoring.py
+++ b/packages/scoring/scoring/league_scoring.py
@@ -1,21 +1,170 @@
 from dataclasses import dataclass
 
+
 def bonus_bins(val, bins):
     return sum(1 for b in bins if val >= b)
 
-@dataclass
-class Statline:
-    Comp: float = 0; Incomp: float = 0; PassYds: float = 0; PassTD: float = 0; INT: float = 0
-    PickSix: float = 0; Pass1D: float = 0; RushYds: float = 0; RushTD: float = 0; Rush1D: float = 0
-    Rec: float = 0; RecYds: float = 0; RecTD: float = 0; Rec1D: float = 0
-    RetYds: float = 0; RetTD: float = 0; TwoPt: float = 0; FumblesLost: float = 0; OffFumRetTD: float = 0
-    e40c: float = 0; e40ptd: float = 0; e40r: float = 0; e40rtd: float = 0; e40rec: float = 0; e40rectd: float = 0
 
-def offense_points(s: Statline) -> float:
+@dataclass
+class OffenseStatline:
+    Comp: float = 0
+    Incomp: float = 0
+    PassYds: float = 0
+    PassTD: float = 0
+    INT: float = 0
+    PickSix: float = 0
+    Pass1D: float = 0
+    RushYds: float = 0
+    RushTD: float = 0
+    Rush1D: float = 0
+    Rec: float = 0
+    RecYds: float = 0
+    RecTD: float = 0
+    Rec1D: float = 0
+    RetYds: float = 0
+    RetTD: float = 0
+    TwoPt: float = 0
+    FumblesLost: float = 0
+    OffFumRetTD: float = 0
+    e40c: float = 0
+    e40ptd: float = 0
+    e40r: float = 0
+    e40rtd: float = 0
+    e40rec: float = 0
+    e40rectd: float = 0
+
+
+def offense_points(s: OffenseStatline) -> float:
     return (
-        0.25*s.Comp - 0.25*s.Incomp + s.PassYds/25 + 2*bonus_bins(s.PassYds,[300,400,500])
-        + 6*s.PassTD - 2*s.INT + 2*s.e40c + 2*s.e40ptd + 0.5*s.Pass1D - 2*s.PickSix
-        + s.RushYds/10 + 2*bonus_bins(s.RushYds,[100,150,200]) + 6*s.RushTD + 2*s.e40r + 2*s.e40rtd + 0.5*s.Rush1D
-        + s.Rec + s.RecYds/10 + 2*bonus_bins(s.RecYds,[100,150,200]) + 6*s.RecTD + 2*s.e40rec + 2*s.e40rectd + 0.5*s.Rec1D
-        + s.RetYds/30 + 6*s.RetTD + 2*s.TwoPt - 2*s.FumblesLost + 6*s.OffFumRetTD
+        0.25 * s.Comp
+        - 0.25 * s.Incomp
+        + s.PassYds / 25
+        + 2 * bonus_bins(s.PassYds, [300, 400, 500])
+        + 6 * s.PassTD
+        - 2 * s.INT
+        + 2 * s.e40c
+        + 2 * s.e40ptd
+        + 0.5 * s.Pass1D
+        - 2 * s.PickSix
+        + s.RushYds / 10
+        + 2 * bonus_bins(s.RushYds, [100, 150, 200])
+        + 6 * s.RushTD
+        + 2 * s.e40r
+        + 2 * s.e40rtd
+        + 0.5 * s.Rush1D
+        + s.Rec
+        + s.RecYds / 10
+        + 2 * bonus_bins(s.RecYds, [100, 150, 200])
+        + 6 * s.RecTD
+        + 2 * s.e40rec
+        + 2 * s.e40rectd
+        + 0.5 * s.Rec1D
+        + s.RetYds / 30
+        + 6 * s.RetTD
+        + 2 * s.TwoPt
+        - 2 * s.FumblesLost
+        + 6 * s.OffFumRetTD
+    )
+
+
+@dataclass
+class KickerStatline:
+    FG0_39: float = 0
+    FG40_49: float = 0
+    FG50_59: float = 0
+    FG60: float = 0
+    FGMiss0_39: float = 0
+    FGMiss40_49: float = 0
+    FGMiss50_59: float = 0
+    FGMiss60: float = 0
+    PAT: float = 0
+    PATMiss: float = 0
+
+
+def kicker_points(s: KickerStatline) -> float:
+    return (
+        3 * s.FG0_39
+        + 4 * s.FG40_49
+        + 5 * s.FG50_59
+        + 6 * s.FG60
+        + 1 * s.PAT
+        - s.FGMiss0_39
+        - s.FGMiss40_49
+        - s.FGMiss50_59
+        - s.FGMiss60
+        - s.PATMiss
+    )
+
+
+@dataclass
+class DefenseStatline:
+    Sack: float = 0
+    INT: float = 0
+    FumRec: float = 0
+    Safety: float = 0
+    TD: float = 0
+    BlkKick: float = 0
+    PtsAllow: float = 0
+    RetYds: float = 0
+    RetTD: float = 0
+
+
+def defense_points_allowed(pa: float) -> float:
+    if pa == 0:
+        return 10
+    if 1 <= pa <= 6:
+        return 7
+    if 7 <= pa <= 13:
+        return 4
+    if 14 <= pa <= 20:
+        return 1
+    if 21 <= pa <= 27:
+        return 0
+    if 28 <= pa <= 34:
+        return -1
+    return -4
+
+
+def defense_points(s: DefenseStatline) -> float:
+    return (
+        s.Sack
+        + 2 * s.INT
+        + 2 * s.FumRec
+        + 2 * s.Safety
+        + 6 * s.TD
+        + 2 * s.BlkKick
+        + s.RetYds / 30
+        + 6 * s.RetTD
+        + defense_points_allowed(s.PtsAllow)
+    )
+
+
+@dataclass
+class IDPStatline:
+    TackleSolo: float = 0
+    TackleAst: float = 0
+    Sack: float = 0
+    INT: float = 0
+    FumForce: float = 0
+    FumRec: float = 0
+    Safety: float = 0
+    TD: float = 0
+    PassDef: float = 0
+    RetYds: float = 0
+    RetTD: float = 0
+
+
+def idp_points(s: IDPStatline) -> float:
+    return (
+        1.5 * s.TackleSolo
+        + 0.75 * s.TackleAst
+        + 4 * s.Sack
+        + 3 * s.INT
+        + 2 * s.FumForce
+        + 2 * s.FumRec
+        + 2 * s.Safety
+        + 6 * s.TD
+        + 1.5 * s.PassDef
+        + s.RetYds / 30
+        + 6 * s.RetTD
     )

--- a/packages/scoring/scoring/tests/test_scoring.py
+++ b/packages/scoring/scoring/tests/test_scoring.py
@@ -1,7 +1,153 @@
-from scoring.league_scoring import Statline, offense_points
+from scoring import (
+    OffenseStatline,
+    KickerStatline,
+    DefenseStatline,
+    IDPStatline,
+    offense_points,
+    kicker_points,
+    defense_points,
+    idp_points,
+)
 
-def test_qb_bonus_and_penalties():
-    s = Statline(Comp=25, Incomp=15, PassYds=405, PassTD=3, INT=1, PickSix=1, Pass1D=12)
+
+def test_offense_qb_bonus_and_penalties():
+    s = OffenseStatline(
+        Comp=25,
+        Incomp=15,
+        PassYds=405,
+        PassTD=3,
+        INT=1,
+        PickSix=1,
+        Pass1D=12,
+    )
     pts = offense_points(s)
-    expected = 0.25*25 - 0.25*15 + 405/25 + 2*2 + 6*3 - 2 - 2 + 0.5*12
+    expected = 0.25 * 25 - 0.25 * 15 + 405 / 25 + 2 * 2 + 6 * 3 - 2 - 2 + 0.5 * 12
     assert round(pts, 2) == round(expected, 2)
+
+
+def test_offense_rb_rush_and_rec_bonus():
+    s = OffenseStatline(
+        RushYds=150,
+        RushTD=1,
+        Rush1D=8,
+        Rec=4,
+        RecYds=50,
+        Rec1D=3,
+    )
+    pts = offense_points(s)
+    expected = (
+        150 / 10
+        + 2 * 2  # 100 and 150 yard bonuses
+        + 6
+        + 0.5 * 8
+        + 4
+        + 50 / 10
+        + 0.5 * 3
+    )
+    assert round(pts, 2) == round(expected, 2)
+
+
+def test_offense_wr_big_play_and_returns():
+    s = OffenseStatline(
+        Rec=7,
+        RecYds=120,
+        RecTD=1,
+        Rec1D=5,
+        e40rec=1,
+        e40rectd=1,
+        RetYds=90,
+        RetTD=1,
+    )
+    pts = offense_points(s)
+    expected = (
+        7 + 120 / 10 + 2 + 6 + 2 * 1 + 2 * 1 + 0.5 * 5 + 90 / 30 + 6  # 100 yard bonus
+    )
+    assert round(pts, 2) == round(expected, 2)
+
+
+def test_kicker_perfect_day():
+    s = KickerStatline(FG0_39=2, FG40_49=1, FG50_59=1, PAT=3)
+    pts = kicker_points(s)
+    expected = 3 * 2 + 4 * 1 + 5 * 1 + 3 * 1
+    assert pts == expected
+
+
+def test_kicker_with_misses():
+    s = KickerStatline(
+        FG40_49=2,
+        FG50_59=1,
+        FGMiss40_49=1,
+        FGMiss50_59=1,
+        PAT=2,
+        PATMiss=1,
+    )
+    pts = kicker_points(s)
+    expected = 4 * 2 + 5 * 1 + 2 - 1 - 1 - 1
+    assert pts == expected
+
+
+def test_kicker_long_range():
+    s = KickerStatline(FG60=1, FG50_59=1, FGMiss0_39=1)
+    pts = kicker_points(s)
+    expected = 6 * 1 + 5 * 1 - 1
+    assert pts == expected
+
+
+def test_defense_shutout():
+    s = DefenseStatline(PtsAllow=0, Sack=3, INT=2, FumRec=1)
+    pts = defense_points(s)
+    expected = 3 + 2 * 2 + 2 * 1 + 10
+    assert pts == expected
+
+
+def test_defense_mid_points_allowed():
+    s = DefenseStatline(PtsAllow=17, Sack=2, TD=1, RetYds=60)
+    pts = defense_points(s)
+    expected = 2 + 6 + 60 / 30 + 1
+    assert pts == expected
+
+
+def test_defense_high_points_allowed():
+    s = DefenseStatline(
+        PtsAllow=38,
+        Sack=1,
+        Safety=1,
+        BlkKick=1,
+        RetTD=1,
+    )
+    pts = defense_points(s)
+    expected = 1 + 2 * 1 + 2 * 1 + 6 * 1 - 4
+    assert pts == expected
+
+
+def test_idp_linebacker():
+    s = IDPStatline(
+        TackleSolo=8,
+        TackleAst=4,
+        Sack=1,
+        FumForce=1,
+        FumRec=1,
+    )
+    pts = idp_points(s)
+    expected = 1.5 * 8 + 0.75 * 4 + 4 * 1 + 2 * 1 + 2 * 1
+    assert pts == expected
+
+
+def test_idp_db_big_play():
+    s = IDPStatline(
+        TackleSolo=5,
+        INT=1,
+        TD=1,
+        PassDef=2,
+        RetYds=30,
+    )
+    pts = idp_points(s)
+    expected = 1.5 * 5 + 3 * 1 + 6 * 1 + 1.5 * 2 + 30 / 30
+    assert pts == expected
+
+
+def test_idp_dl_safety():
+    s = IDPStatline(TackleSolo=3, Sack=2, Safety=1)
+    pts = idp_points(s)
+    expected = 1.5 * 3 + 4 * 2 + 2 * 1
+    assert pts == expected


### PR DESCRIPTION
## Summary
- expand scoring package with offense, kicker, defense, and IDP point calculations
- expose new scoring utilities and add golden tests for multiple statlines
- document completion of scoring engine in status report

## Testing
- `ruff check packages/scoring`
- `black packages/scoring --check`
- `mypy packages/scoring`
- `cd apps/api && pytest -q`
- `pytest packages/scoring/scoring/tests/test_scoring.py`


------
https://chatgpt.com/codex/tasks/task_e_68b58d581aa88323858a436552e51d56