### PR TITLE
feat: add projection pipeline estimators and tasks

### DIFF
--- a/apps/api/alembic/versions/004_add_projection_data.py
+++ b/apps/api/alembic/versions/004_add_projection_data.py
@@ -1,0 +1,25 @@
+"""Add projection data column
+
+Revision ID: 004
+Revises: 003
+Create Date: 2023-01-01 10:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '004'
+down_revision = '003'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('projections', sa.Column('data', sa.JSON(), nullable=False, server_default='{}'))
+    op.add_column('projections', sa.Column('variance', sa.Float(), nullable=True))
+    op.alter_column('projections', 'data', server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column('projections', 'variance')
+    op.drop_column('projections', 'data')

--- a/apps/api/app/models.py
+++ b/apps/api/app/models.py
@@ -8,6 +8,7 @@ from sqlalchemy import (
     func,
     Boolean,
     Float,
+    JSON,
 )
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
@@ -129,6 +130,8 @@ class Projection(Base):
     player_id = Column(Integer, ForeignKey("players.id"), nullable=False)
     week = Column(Integer, nullable=False)
     projected_points = Column(Float, nullable=False)
+    data = Column(JSON, nullable=False)
+    variance = Column(Float, nullable=True)
 
     player = relationship("Player", back_populates="projections")
 

--- a/packages/projections/projections/__init__.py
+++ b/packages/projections/projections/__init__.py
@@ -1,0 +1,3 @@
+from .estimators import project_offense
+
+__all__ = ["project_offense"]

--- a/packages/projections/projections/estimators.py
+++ b/packages/projections/projections/estimators.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Dict, Tuple
+
+from scoring import OffenseStatline, offense_points
+
+
+def project_offense(
+    baselines: Dict[str, float], proe: float, waf: float
+) -> Tuple[Dict[str, float], float]:
+    """Simple offense projection using baseline rates, PROE, and weather."""
+    pass_att = baselines.get("pass_attempts", 0) * (1 + proe) * waf
+    comp_rate = baselines.get("comp_rate", 0.65)
+    completions = pass_att * comp_rate
+    pass_yds = pass_att * baselines.get("yards_per_attempt", 7) * waf
+    pass_td = pass_att * baselines.get("td_rate", 0.05)
+    interceptions = pass_att * baselines.get("int_rate", 0.02)
+
+    rush_att = baselines.get("rush_attempts", 0) * waf
+    rush_yds = rush_att * baselines.get("yards_per_rush", 4)
+    rush_td = rush_att * baselines.get("rush_td_rate", 0.02)
+
+    targets = baselines.get("targets", 0) * (1 + proe) * waf
+    catch_rate = baselines.get("catch_rate", 0.6)
+    receptions = targets * catch_rate
+    rec_yds = receptions * baselines.get("yards_per_rec", 10) * waf
+    rec_td = receptions * baselines.get("rec_td_rate", 0.05)
+
+    stat = OffenseStatline(
+        Comp=completions,
+        Incomp=max(pass_att - completions, 0),
+        PassYds=pass_yds,
+        PassTD=pass_td,
+        INT=interceptions,
+        RushYds=rush_yds,
+        RushTD=rush_td,
+        Rec=receptions,
+        RecYds=rec_yds,
+        RecTD=rec_td,
+    )
+    points = offense_points(stat)
+    return asdict(stat), points

--- a/packages/projections/projections/tests/test_estimators.py
+++ b/packages/projections/projections/tests/test_estimators.py
@@ -1,0 +1,38 @@
+from projections import project_offense
+
+
+def sample_baselines():
+    return {
+        "pass_attempts": 30,
+        "yards_per_attempt": 7,
+        "td_rate": 0.05,
+        "int_rate": 0.02,
+        "rush_attempts": 5,
+        "yards_per_rush": 4.5,
+        "rush_td_rate": 0.03,
+        "targets": 8,
+        "catch_rate": 0.65,
+        "yards_per_rec": 12,
+        "rec_td_rate": 0.05,
+    }
+
+
+def test_shape_and_points():
+    cat, pts = project_offense(sample_baselines(), proe=0.0, waf=1.0)
+    assert pts > 0
+    for key in ["PassYds", "RushYds", "Rec", "RecYds"]:
+        assert key in cat
+
+
+def test_proe_increases_targets():
+    base = sample_baselines()
+    cat_low, _ = project_offense(base, proe=0.0, waf=1.0)
+    cat_high, _ = project_offense(base, proe=0.5, waf=1.0)
+    assert cat_high["Rec"] > cat_low["Rec"]
+
+
+def test_weather_sensitivity():
+    base = sample_baselines()
+    cat_good, _ = project_offense(base, proe=0.0, waf=1.0)
+    cat_bad, _ = project_offense(base, proe=0.0, waf=0.5)
+    assert cat_bad["PassYds"] < cat_good["PassYds"]

--- a/packages/projections/pyproject.toml
+++ b/packages/projections/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.pytest.ini_options]
+addopts = "-q"

--- a/services/worker/tests/test_projection.py
+++ b/services/worker/tests/test_projection.py
@@ -1,0 +1,37 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from tasks import generate_projections
+from app.models import Base, Baseline, Player, Projection, Weather
+
+
+def setup_db():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(bind=engine)()
+
+
+def test_generate_projections_inserts_rows():
+    session = setup_db()
+    player = Player(id=1, name="Tester", position="QB")
+    session.add(player)
+    session.commit()
+    baselines = [
+        Baseline(player_id=1, metric="pass_attempts", value=30),
+        Baseline(player_id=1, metric="yards_per_attempt", value=7),
+        Baseline(player_id=1, metric="td_rate", value=0.05),
+        Baseline(player_id=1, metric="int_rate", value=0.02),
+        Baseline(player_id=1, metric="rush_attempts", value=5),
+        Baseline(player_id=1, metric="yards_per_rush", value=4),
+        Baseline(player_id=1, metric="rush_td_rate", value=0.02),
+        Baseline(player_id=1, metric="proe", value=0.1),
+    ]
+    session.add_all(baselines)
+    session.add(Weather(game_id="1-1", waf=0.8))
+    session.commit()
+
+    count = generate_projections(session, week=1)
+    assert count == 1
+    proj = session.query(Projection).filter_by(player_id=1, week=1).one()
+    assert proj.projected_points > 0
+    assert proj.data["PassYds"] > 0


### PR DESCRIPTION
## Summary
- support projection JSON storage with variance on Projection model
- add projection estimator using baseline rates, PROE and WAF
- expose Celery task to generate weekly projections

## Env Changes
- none

## Migrations
- `004_add_projection_data.py`

## Testing
- `ruff check apps/api/app/models.py services/worker/tasks.py packages/projections/projections/estimators.py services/worker/tests/test_projection.py packages/projections/projections/tests/test_estimators.py`
- `black --check apps/api/app/models.py services/worker/tasks.py packages/projections/projections/estimators.py services/worker/tests/test_projection.py packages/projections/projections/tests/test_estimators.py`
- `mypy packages/projections --ignore-missing-imports`
- `PYTHONPATH=packages/scoring:packages/projections pytest packages/projections/projections/tests/test_estimators.py services/worker/tests/test_projection.py -q`
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b5e628f6cc83238370278172e1667f