### PR TITLE
Use timezone-aware datetime throughout API

### DIFF
--- a/apps/api/app/routers/auth.py
+++ b/apps/api/app/routers/auth.py
@@ -1,6 +1,6 @@
 import base64
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from typing import Dict
 
 from fastapi import APIRouter, Depends, HTTPException, Response
@@ -24,7 +24,7 @@ state_store: Dict[str, datetime] = {}
 @router.get("/yahoo/login")
 def yahoo_login():
     state = base64.urlsafe_b64encode(os.urandom(16)).decode()
-    state_store[state] = datetime.utcnow()
+    state_store[state] = datetime.now(UTC)
     params = (
         f"client_id={settings.yahoo_client_id}&response_type=code&"
         f"redirect_uri={settings.yahoo_redirect_uri}&scope={SCOPE}&state={state}"
@@ -68,7 +68,7 @@ def yahoo_callback(
 
     enc_access = encryption.encrypt(access_token)
     enc_refresh = encryption.encrypt(refresh_token) if refresh_token else None
-    expires_at = datetime.utcnow() + timedelta(seconds=expires_in)
+    expires_at = datetime.now(UTC) + timedelta(seconds=expires_in)
 
     oauth = db.query(OAuthToken).filter_by(user_id=user.id, provider="yahoo").first()
     if oauth:

--- a/apps/api/app/session.py
+++ b/apps/api/app/session.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from typing import Optional
 from jose import JWTError, jwt
 from fastapi import Response
@@ -13,7 +13,7 @@ class SessionManager:
     def create_token(user_id: int) -> str:
         """Create a JWT token for the user"""
         data = {"sub": str(user_id)}
-        expires = datetime.utcnow() + timedelta(days=7)  # 7-day expiry
+        expires = datetime.now(UTC) + timedelta(days=7)  # 7-day expiry
         data.update({"exp": expires})
         return jwt.encode(data, settings.jwt_secret, algorithm="HS256")
 

--- a/apps/api/app/yahoo_oauth.py
+++ b/apps/api/app/yahoo_oauth.py
@@ -1,7 +1,7 @@
 import base64
 import random
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 from typing import Dict
 
 import httpx
@@ -64,12 +64,12 @@ class YahooOAuthClient:
 
     def ensure_valid_token(self, db: Session, token: OAuthToken) -> str:
         """Return decrypted access token, refreshing if expiring soon."""
-        if token.expires_at and token.expires_at - datetime.utcnow() < timedelta(minutes=5):
+        if token.expires_at and token.expires_at - datetime.now(UTC) < timedelta(minutes=5):
             data = self.refresh_token(self.encryption.decrypt(token.refresh_token))
             token.access_token = self.encryption.encrypt(data["access_token"])
             if data.get("refresh_token"):
                 token.refresh_token = self.encryption.encrypt(data["refresh_token"])
-            token.expires_at = datetime.utcnow() + timedelta(seconds=data.get("expires_in", 0))
+            token.expires_at = datetime.now(UTC) + timedelta(seconds=data.get("expires_in", 0))
             token.scope = data.get("scope")
             db.add(token)
             db.commit()

--- a/apps/api/tests/test_oauth.py
+++ b/apps/api/tests/test_oauth.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 
 import respx
 
@@ -57,7 +57,7 @@ def test_refresh_token_if_expiring(db_session):
         provider="yahoo",
         access_token=enc.encrypt("old"),
         refresh_token=enc.encrypt("refresh"),
-        expires_at=datetime.utcnow() + timedelta(minutes=4),
+        expires_at=datetime.now(UTC) + timedelta(minutes=4),
     )
     db_session.add(token)
     db_session.commit()

--- a/apps/api/tests/test_yahoo.py
+++ b/apps/api/tests/test_yahoo.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, UTC
 
 import respx
 
@@ -17,7 +17,7 @@ def _setup_user(db_session):
         provider="yahoo",
         access_token=enc.encrypt("old"),
         refresh_token=enc.encrypt("refresh"),
-        expires_at=datetime.utcnow() + timedelta(hours=1),
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
     )
     db_session.add(token)
     db_session.commit()
@@ -99,7 +99,7 @@ def test_league_teams_rosters_matchups(client, db_session):
 
 def test_refresh_path(client, db_session):
     user, token, enc = _setup_user(db_session)
-    token.expires_at = datetime.utcnow() + timedelta(minutes=4)
+    token.expires_at = datetime.now(UTC) + timedelta(minutes=4)
     db_session.add(token)
     db_session.commit()
     _auth_client(client, user)

--- a/docs/FINDINGS.md
+++ b/docs/FINDINGS.md
@@ -25,12 +25,10 @@ The repository is a monorepo containing:
 - **Phase 8 – Lineup Optimization** and subsequent phases (Waivers, Streamers, Frontend Pages, Scheduling, Security, Docs & Deploy Config) show no implementation.
 
 ## Observations & Formatting Notes
-- Multiple modules use `datetime.utcnow()`, generating deprecation warnings.
 - The web app lacks a `test` script; `npm test` fails.
 - Documentation is minimal; README only covers basic dev commands.
 
 ## Plan / Attack
-- Replace deprecated `datetime.utcnow()` with timezone-aware calls.
 - Implement remaining phases, starting with integrating the projection pipeline.
 - Expand web UI, tests, and documentation.
 - Add `npm test` script or clarify testing approach for the web app.

--- a/docs/FOLLOWUP.md
+++ b/docs/FOLLOWUP.md
@@ -3,22 +3,20 @@
 Date: 2025-09-01
 
 ## Items Requiring Attention
-1. **Timezone Handling**
-   - Replace all uses of `datetime.utcnow()` with `datetime.now(datetime.UTC)` across the API and tests to remove deprecation warnings.
-2. **Projection Pipeline Integration**
+1. **Projection Pipeline Integration**
    - Wire the `projections` package into worker tasks and expose projection data through API endpoints.
    - Persist generated projections in the database.
-3. **Lineup Optimization (Phase 8)**
+2. **Lineup Optimization (Phase 8)**
    - Implement optimization algorithms and corresponding API routes.
-4. **Waivers & Streamers (Phase 9)**
+3. **Waivers & Streamers (Phase 9)**
    - Develop ranking logic and exposure endpoints.
-5. **Frontend Expansion (Phase 10)**
+4. **Frontend Expansion (Phase 10)**
    - Flesh out Next.js pages beyond the league stub and add client-side tests.
-6. **Scheduling & Security (Phases 11–12)**
+5. **Scheduling & Security (Phases 11–12)**
    - Add task scheduling with configurable intervals and implement logging/backoff/security hardening.
-7. **Docs & Deployment Config (Phase 13)**
+6. **Docs & Deployment Config (Phase 13)**
    - Author comprehensive README, provide Postman/Thunder collections, and add deployment templates.
-8. **Web Testing Script**
+7. **Web Testing Script**
    - Add `npm test` or equivalent for the web app, or update docs to describe testing approach.
 
 ## Signature

--- a/docs/IMPLEMENTATION_AND_STATUS_REPORT.md
+++ b/docs/IMPLEMENTATION_AND_STATUS_REPORT.md
@@ -12,6 +12,7 @@ Date: 2025-09-01
 - **Phase 6 – Scoring Engine**: Completed. Offense, kicker, defense, and IDP scoring utilities with golden tests.
 - **Phase 7 – Projection Pipeline**: Partially implemented. Basic offensive estimator and worker hooks exist with tests, but projections are not yet exposed via API or stored.
 - **Phases 8–13**: Not started. Lineup optimization, waivers/streamers, frontend pages, scheduling, security hardening, and deployment docs remain outstanding.
+- **Timezone Handling**: Replaced all uses of `datetime.utcnow()` with `datetime.now(datetime.UTC)` across API modules and tests.
 
 ## Production Readiness
 Phases 0–6 have passing tests and are suitable for production usage. Phase 7 requires integration work, and later phases remain undeveloped.


### PR DESCRIPTION
## Summary
- replace deprecated `datetime.utcnow()` with `datetime.now(datetime.UTC)` across API modules and tests
- drop timezone follow-up item and update docs
- record timezone handling progress in status report

## Testing
- `pytest` (fails: ModuleNotFoundError: No module named 'projections')
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68b5f456b6488323a4781e977ab4c5d0