### PR TITLE
feat(web): add streamers page

### DIFF
--- a/apps/web/app/l/[leagueId]/matchup/[week]/page.tsx
+++ b/apps/web/app/l/[leagueId]/matchup/[week]/page.tsx
@@ -27,7 +27,7 @@ export default async function MatchupPage({
         Week {params.week} Matchups
       </h1>
       <ul>
-        {matchups.map((m, idx) => (
+        {matchups.map((m: { teams: string[] }, idx: number) => (
           <li key={idx}>{m.teams.join(" vs ")}</li>
         ))}
       </ul>

--- a/apps/web/app/l/[leagueId]/streamers/[week]/page.tsx
+++ b/apps/web/app/l/[leagueId]/streamers/[week]/page.tsx
@@ -1,0 +1,42 @@
+import { apiFetch } from "../../../../../lib/api";
+
+async function getStreamers(week: string) {
+  const [def, idp] = await Promise.all([
+    apiFetch<any[]>(`/streamers/def?week=${week}`, { cache: "no-store" }),
+    apiFetch<any[]>(`/streamers/idp?week=${week}`, { cache: "no-store" }),
+  ]);
+  return { def, idp };
+}
+
+export default async function StreamersPage({
+  params,
+}: {
+  params: { leagueId: string; week: string };
+}) {
+  const { def, idp } = await getStreamers(params.week);
+  return (
+    <div>
+      <h1 className="mb-4 text-xl font-bold">Week {params.week} Streamers</h1>
+      <section>
+        <h2 className="mt-2 font-semibold">DEF Streamers</h2>
+        <ul>
+          {def.map((s) => (
+            <li key={s.player_id}>
+              {s.rank}. {s.name} ({s.projected_points})
+            </li>
+          ))}
+        </ul>
+      </section>
+      <section className="mt-4">
+        <h2 className="mt-2 font-semibold">IDP Streamers</h2>
+        <ul>
+          {idp.map((s) => (
+            <li key={s.player_id}>
+              {s.rank}. {s.name} ({s.projected_points})
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/docs/FOLLOWUP.md
+++ b/docs/FOLLOWUP.md
@@ -3,13 +3,11 @@
 Date: 2025-09-03
 
 ## Items Requiring Attention
-1. **Waivers & Streamers (Phase 9)**
-   - Develop ranking logic and exposure endpoints.
-2. **Frontend Expansion (Phase 10)**
-   - Flesh out Next.js pages beyond the league stub and add client-side tests.
-3. **Scheduling & Security (Phases 11–12)**
+1. **Frontend Expansion (Phase 10)**
+   - Complete waivers and settings pages and add client-side tests.
+2. **Scheduling & Security (Phases 11–12)**
    - Add task scheduling with configurable intervals and implement logging/backoff/security hardening.
-4. **Docs & Deployment Config (Phase 13)**
+3. **Docs & Deployment Config (Phase 13)**
    - Author comprehensive README, provide Postman/Thunder collections, and add deployment templates.
 
 ## Signature

--- a/docs/IMPLEMENTATION_AND_STATUS_REPORT.md
+++ b/docs/IMPLEMENTATION_AND_STATUS_REPORT.md
@@ -13,7 +13,7 @@ Date: 2025-09-03
 - **Phase 7 – Projection Pipeline**: Completed. Worker persists offensive projections to the database and an API endpoint serves player projections with variance and category breakdowns.
 - **Phase 8 – Lineup Optimization**: Initial optimizer package providing a backtracking algorithm to fill roster slots based on projected points, with unit tests.
 - **Phase 9 – Waivers & Streamers**: Implemented Celery `waiver_shortlist` task and API endpoints for team waivers and DEF/IDP streamers with deterministic ranking tests.
-- **Phase 10 – Frontend (Next.js)**: In progress. Added Yahoo login page and leagues table using TanStack Table; dependencies for Recharts and TanStack Table installed. Implemented matchups page and Node-based smoke tests (`npm test`).
+- **Phase 10 – Frontend (Next.js)**: In progress. Added Yahoo login page and leagues table using TanStack Table; dependencies for Recharts and TanStack Table installed. Implemented matchups and streamers pages alongside Node-based smoke tests (`npm test`).
 - **Phases 11–13**: Not started. Scheduling, security hardening, and deployment docs remain outstanding.
 - **Timezone Handling**: Replaced all uses of `datetime.utcnow()` with `datetime.now(datetime.UTC)` across API modules and tests.
 
@@ -21,7 +21,7 @@ Date: 2025-09-03
 Phases 0–9 have passing tests and are suitable for production usage. Phase 10 frontend work has begun but is incomplete; later phases remain undeveloped.
 
 ## Next Steps
-Continue Phase 10 frontend expansion—matchup, waivers, streamers, and settings pages—then proceed through remaining phases as outlined in `docs/FOLLOWUP.md`.
+Continue Phase 10 frontend expansion—add waivers and settings pages—then proceed through remaining phases as outlined in `docs/FOLLOWUP.md`.
 
 ---
 


### PR DESCRIPTION
## Summary
- add Next.js page to display weekly DEF and IDP streamer candidates
- type matchups page for successful TypeScript builds
- update project status and follow-up docs

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b60b283e2483239ddd5a6020415af1