### PR TITLE
feat(web): add waivers and settings pages with tests

### DIFF
--- a/apps/web/app/l/[leagueId]/waivers/[week]/page.tsx
+++ b/apps/web/app/l/[leagueId]/waivers/[week]/page.tsx
@@ -1,0 +1,36 @@
+import { apiFetch } from "../../../../../lib/api";
+import { mapWaivers } from "../../../../../lib/waivers";
+
+async function getWaivers(teamId: string, week: string) {
+  const data = await apiFetch<any>(
+    `/team/${teamId}/waivers?week=${week}&horizon=2`,
+    { cache: "no-store" }
+  );
+  return mapWaivers(data.waivers ?? []);
+}
+
+export default async function WaiversPage({
+  params,
+  searchParams,
+}: {
+  params: { leagueId: string; week: string };
+  searchParams: { teamId?: string };
+}) {
+  const teamId = searchParams.teamId;
+  if (!teamId) {
+    return <div>teamId query param required</div>;
+  }
+  const waivers = await getWaivers(teamId, params.week);
+  return (
+    <div>
+      <h1 className="mb-4 text-xl font-bold">Week {params.week} Waivers</h1>
+      <ul>
+        {waivers.map((w) => (
+          <li key={w.player_id}>
+            {w.order}. {w.name} ({w.delta_xfp})
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/app/settings/page.tsx
+++ b/apps/web/app/settings/page.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+import { parseCsv } from "../../lib/csv";
+
+export default function SettingsPage() {
+  const [rows, setRows] = useState<string[][]>([]);
+  const [sheetUrl, setSheetUrl] = useState("");
+
+  const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const text = await file.text();
+    setRows(parseCsv(text));
+  };
+
+  return (
+    <div>
+      <h1 className="mb-4 text-xl font-bold">Settings</h1>
+      <div>
+        <label className="block font-semibold">Google Sheets URL</label>
+        <input
+          type="text"
+          value={sheetUrl}
+          onChange={(e) => setSheetUrl(e.target.value)}
+          className="border p-1"
+        />
+      </div>
+      <div className="mt-4">
+        <label className="block font-semibold">Import CSV</label>
+        <input type="file" accept=".csv" onChange={handleFile} />
+      </div>
+      {rows.length > 0 && (
+        <table className="mt-4">
+          <tbody>
+            {rows.map((r, i) => (
+              <tr key={i}>
+                {r.map((c, j) => (
+                  <td key={j} className="px-2">
+                    {c}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/apps/web/lib/csv.js
+++ b/apps/web/lib/csv.js
@@ -1,0 +1,12 @@
+/**
+ * Parse a CSV string into rows of cells.
+ * @param {string} text
+ * @returns {string[][]}
+ */
+export function parseCsv(text) {
+  return text
+    .trim()
+    .split(/\r?\n/)
+    .filter((line) => line.length > 0)
+    .map((line) => line.split(',').map((c) => c.trim()));
+}

--- a/apps/web/lib/waivers.js
+++ b/apps/web/lib/waivers.js
@@ -1,0 +1,13 @@
+/**
+ * Map raw waiver data to simplified objects.
+ * @param {any[]} raw
+ * @returns {{player_id: number|string, name: string, delta_xfp: number, order: number}[]}
+ */
+export function mapWaivers(raw) {
+  return raw.map((w) => ({
+    player_id: w.player_id ?? w.id ?? 0,
+    name: w.name ?? "Unknown Player",
+    delta_xfp: w.delta_xfp ?? w.xfp ?? 0,
+    order: w.order ?? 0,
+  }));
+}

--- a/apps/web/tests/settings.test.js
+++ b/apps/web/tests/settings.test.js
@@ -1,0 +1,9 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { parseCsv } from '../lib/csv.js';
+
+test('parseCsv splits lines and cells', () => {
+  const csv = 'a,b\n1,2';
+  const rows = parseCsv(csv);
+  assert.deepStrictEqual(rows, [ ['a','b'], ['1','2'] ]);
+});

--- a/apps/web/tests/waivers.test.js
+++ b/apps/web/tests/waivers.test.js
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { mapWaivers } from '../lib/waivers.js';
+
+test('mapWaivers normalizes waiver fields', () => {
+  const raw = [
+    { player_id: 1, delta_xfp: 2, order: 1, name: 'A' },
+    { id: 2, xfp: 3, order: 2, name: 'B' },
+  ];
+  const mapped = mapWaivers(raw);
+  assert.deepStrictEqual(mapped, [
+    { player_id: 1, name: 'A', delta_xfp: 2, order: 1 },
+    { player_id: 2, name: 'B', delta_xfp: 3, order: 2 },
+  ]);
+});

--- a/docs/IMPLEMENTATION_AND_STATUS_REPORT.md
+++ b/docs/IMPLEMENTATION_AND_STATUS_REPORT.md
@@ -13,7 +13,7 @@ Date: 2025-09-03
 - **Phase 7 – Projection Pipeline**: Completed. Worker persists offensive projections to the database and an API endpoint serves player projections with variance and category breakdowns.
 - **Phase 8 – Lineup Optimization**: Initial optimizer package providing a backtracking algorithm to fill roster slots based on projected points, with unit tests.
 - **Phase 9 – Waivers & Streamers**: Implemented Celery `waiver_shortlist` task and API endpoints for team waivers and DEF/IDP streamers with deterministic ranking tests.
-- **Phase 10 – Frontend (Next.js)**: In progress. Added Yahoo login page and leagues table using TanStack Table; dependencies for Recharts and TanStack Table installed. Implemented matchups and streamers pages alongside Node-based smoke tests (`npm test`).
+- **Phase 10 – Frontend (Next.js)**: In progress. Added Yahoo login page, leagues table, matchups, waivers, streamers, and settings pages with client-side CSV import; Node-based tests cover arithmetic, waiver mapping, and CSV parsing.
 - **Phases 11–13**: Not started. Scheduling, security hardening, and deployment docs remain outstanding.
 - **Timezone Handling**: Replaced all uses of `datetime.utcnow()` with `datetime.now(datetime.UTC)` across API modules and tests.
 
@@ -21,7 +21,7 @@ Date: 2025-09-03
 Phases 0–9 have passing tests and are suitable for production usage. Phase 10 frontend work has begun but is incomplete; later phases remain undeveloped.
 
 ## Next Steps
-Continue Phase 10 frontend expansion—add waivers and settings pages—then proceed through remaining phases as outlined in `docs/FOLLOWUP.md`.
+Proceed to Phases 11–13 as outlined in `docs/FOLLOWUP.md`.
 
 ---
 


### PR DESCRIPTION
## Summary
- add waiver view with team-aware fetch and mapping helper
- implement settings page with CSV import utility
- test waiver mapping and CSV parsing via Node's test runner and update status report

## Testing
- `cd apps/web && npm test`
- `cd .. && pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b60e225bc08323b761f4f9e8da819d