### PR TITLE
feat(api): add logging filters and retry policy

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -4,6 +4,7 @@ REDIS_URL=redis://redis:6379/0
 JWT_SECRET=REPLACE_ME
 TOKEN_CRYPTO_KEY=REPLACE_ME
 ALLOW_DEBUG_USER=false
+CORS_ORIGINS=http://localhost:3000,https://misfits.westfam.media
 
 # External APIs
 YAHOO_CLIENT_ID=REPLACE_ME

--- a/apps/api/app/logging.py
+++ b/apps/api/app/logging.py
@@ -1,0 +1,23 @@
+import logging
+import re
+
+SECRET_FIELDS = ["token", "secret", "password"]
+EMAIL_RE = re.compile(r"([\w.\-+]+)@([\w.\-]+)")
+
+class MaskingFilter(logging.Filter):
+    """Filter that masks secrets and emails in log records."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        message = record.getMessage()
+        for field in SECRET_FIELDS:
+            message = re.sub(rf"({field}=)[^\s&]+", r"\1***", message, flags=re.IGNORECASE)
+        message = EMAIL_RE.sub(r"<redacted>@\2", message)
+        record.msg = message
+        record.args = ()
+        return True
+
+def configure_logging() -> None:
+    """Configure root logger with masking filter."""
+    handler = logging.StreamHandler()
+    handler.addFilter(MaskingFilter())
+    logging.basicConfig(level=logging.INFO, handlers=[handler], force=True)

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -1,12 +1,17 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+
 from .routers import health, auth, yahoo, optimize, players, waivers, streamers
+from .logging import configure_logging
+from .settings import settings
+
+configure_logging()
 
 app = FastAPI(title="Fantasy Edge API")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000", "https://misfits.westfam.media"],
+    allow_origins=settings.cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/apps/api/app/session.py
+++ b/apps/api/app/session.py
@@ -21,13 +21,15 @@ class SessionManager:
     def set_session_cookie(response: Response, user_id: int) -> None:
         """Set the session cookie in the response"""
         token = SessionManager.create_token(user_id)
+        secure = not settings.allow_debug_user
+        samesite = "None" if secure else "Lax"
         response.set_cookie(
             key=SessionManager.COOKIE_NAME,
             value=token,
-            httponly=True,  # Not accessible from JavaScript
-            samesite="Lax",  # CSRF protection
-            secure=False,  # Set to True in production
-            max_age=60 * 60 * 24 * 7,  # 7 days in seconds
+            httponly=True,
+            samesite=samesite,
+            secure=secure,
+            max_age=60 * 60 * 24 * 7,
         )
 
     @staticmethod

--- a/apps/api/app/settings.py
+++ b/apps/api/app/settings.py
@@ -9,6 +9,10 @@ class Settings(BaseSettings):
     jwt_secret: str = "change-me"
     token_crypto_key: str = "REPLACE_ME"  # 32+ character key for Fernet encryption
     allow_debug_user: bool = False  # Enable debug bypass header
+    cors_origins: list[str] = [
+        "http://localhost:3000",
+        "https://misfits.westfam.media",
+    ]
     nws_user_agent: str = "League of Misfits Edge (contact: you@example.com)"
 
     class Config:

--- a/apps/api/app/yahoo_client.py
+++ b/apps/api/app/yahoo_client.py
@@ -17,6 +17,7 @@ class YahooFantasyClient:
 
     def __init__(self, oauth_client: YahooOAuthClient):
         self.oauth_client = oauth_client
+        self.max_retries = 3
 
     def _request(
         self, db: Session, user: User, resource: str, params: Optional[Dict[str, str]] = None
@@ -29,15 +30,17 @@ class YahooFantasyClient:
         params = params or {}
         params.setdefault("format", "json")
         headers = {"Authorization": f"Bearer {access}"}
-        for attempt in range(3):
+        for attempt in range(self.max_retries):
             try:
                 resp = httpx.get(url, params=params, headers=headers, timeout=10)
                 resp.raise_for_status()
                 return resp.json()
             except httpx.HTTPError:
-                if attempt == 2:
+                if attempt == self.max_retries - 1:
                     raise
-                time.sleep(0.1 * (2**attempt) + random.random() / 10)
+                base = 0.1 * (2**attempt)
+                jitter = random.uniform(0, 0.1)
+                time.sleep(base + jitter)
         return {}
 
     def get(
@@ -45,3 +48,17 @@ class YahooFantasyClient:
     ) -> Dict:
         """Public GET wrapper"""
         return self._request(db, user, resource, params)
+
+    def snapshot(
+        self, db: Session, user: User, resource: str, params: Optional[Dict[str, str]] = None
+    ) -> Dict:
+        """Fetch a resource and persist the JSON snapshot to disk."""
+        data = self._request(db, user, resource, params)
+        path = f"snapshots/{resource.strip('/').replace('/', '_')}.json"
+        import os
+        os.makedirs("snapshots", exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            import json
+
+            json.dump(data, f)
+        return data

--- a/apps/api/tests/test_logging_filter.py
+++ b/apps/api/tests/test_logging_filter.py
@@ -1,0 +1,14 @@
+import logging
+from app.logging import configure_logging
+
+
+def test_logging_masks_secrets(caplog):
+    configure_logging()
+    logging.getLogger().addHandler(caplog.handler)
+    logger = logging.getLogger("test")
+    with caplog.at_level(logging.INFO):
+        logger.info("access_token=abcd email=user@example.com secret=123")
+    record = caplog.records[0]
+    assert "access_token=***" in record.message
+    assert "secret=***" in record.message
+    assert "<redacted>@example.com" in record.message

--- a/apps/api/tests/test_retry_policy.py
+++ b/apps/api/tests/test_retry_policy.py
@@ -1,0 +1,57 @@
+import random
+import time
+import httpx
+
+from app.yahoo_client import YahooFantasyClient
+
+
+class DummyOAuth:
+    def ensure_valid_token(self, db, token):
+        return "token"
+
+
+class DummyToken:
+    pass
+
+
+class DummyQuery:
+    def filter_by(self, **kwargs):
+        return self
+
+    def first(self):
+        return DummyToken()
+
+
+class DummyDB:
+    def query(self, model):
+        return DummyQuery()
+
+
+class DummyUser:
+    id = 1
+
+
+def test_exponential_backoff(monkeypatch):
+    client = YahooFantasyClient(DummyOAuth())
+
+    calls = {"count": 0}
+
+    def fake_get(url, params, headers, timeout):
+        if calls["count"] < 2:
+            calls["count"] += 1
+            raise httpx.HTTPError("boom")
+        class Resp:
+            def raise_for_status(self):
+                return None
+            def json(self):
+                return {"ok": True}
+        return Resp()
+
+    sleeps = []
+    monkeypatch.setattr(httpx, "get", fake_get)
+    monkeypatch.setattr(time, "sleep", lambda x: sleeps.append(x))
+    monkeypatch.setattr(random, "uniform", lambda a, b: 0)
+
+    data = client.get(DummyDB(), DummyUser(), "/test")
+    assert data == {"ok": True}
+    assert sleeps == [0.1, 0.2]

--- a/apps/api/tests/test_security_settings.py
+++ b/apps/api/tests/test_security_settings.py
@@ -1,0 +1,27 @@
+from fastapi import Response
+
+from app.session import SessionManager
+from app.settings import settings
+
+
+def test_cookie_prod(monkeypatch):
+    resp = Response()
+    monkeypatch.setattr(settings, "allow_debug_user", False)
+    SessionManager.set_session_cookie(resp, 1)
+    cookie = resp.headers.get("set-cookie")
+    assert "Secure" in cookie
+    assert "SameSite=None" in cookie
+
+
+def test_cookie_dev(monkeypatch):
+    resp = Response()
+    monkeypatch.setattr(settings, "allow_debug_user", True)
+    SessionManager.set_session_cookie(resp, 1)
+    cookie = resp.headers.get("set-cookie")
+    assert "Secure" not in cookie
+    assert "SameSite=Lax" in cookie
+
+
+def test_cors_defaults():
+    assert "http://localhost:3000" in settings.cors_origins
+    assert "https://misfits.westfam.media" in settings.cors_origins

--- a/apps/api/tests/test_snapshot.py
+++ b/apps/api/tests/test_snapshot.py
@@ -1,0 +1,45 @@
+import json
+from pathlib import Path
+
+from app.yahoo_client import YahooFantasyClient
+
+
+class DummyOAuth:
+    def ensure_valid_token(self, db, token):
+        return "token"
+
+
+class DummyToken:
+    pass
+
+
+class DummyQuery:
+    def filter_by(self, **kwargs):
+        return self
+
+    def first(self):
+        return DummyToken()
+
+
+class DummyDB:
+    def query(self, model):
+        return DummyQuery()
+
+
+class DummyUser:
+    id = 1
+
+
+def test_snapshot_creates_file(monkeypatch, tmp_path):
+    client = YahooFantasyClient(DummyOAuth())
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        client,
+        "_request",
+        lambda db, user, resource, params: {"data": 1},
+    )
+    client.snapshot(DummyDB(), DummyUser(), "/team/1/roster")
+    path = tmp_path / "snapshots" / "team_1_roster.json"
+    assert path.exists()
+    with path.open() as f:
+        assert json.load(f) == {"data": 1}

--- a/docs/ERROR_BUDGET_AND_RETRY_POLICY.md
+++ b/docs/ERROR_BUDGET_AND_RETRY_POLICY.md
@@ -1,0 +1,11 @@
+# Error Budget and Retry Policy
+
+The API client uses an exponential backoff strategy with jitter when
+communicating with Yahoo. Requests are retried up to three times with
+delays of `0.1 * 2^n` seconds plus a random 0–0.1 second jitter. This
+helps smooth traffic spikes and guards against transient failures.
+
+We maintain an informal error budget of 99% success over rolling seven days.
+Exceeding this threshold triggers investigation and potential backoff
+adjustments. Persistent failures are surfaced through structured logs and
+metrics derived from those logs.

--- a/docs/FOLLOWUP.md
+++ b/docs/FOLLOWUP.md
@@ -5,9 +5,7 @@ Date: 2025-09-03
 ## Items Requiring Attention
 1. **Frontend Expansion (Phase 10)**
    - Complete waivers and settings pages and add client-side tests.
-2. **Scheduling & Security (Phases 11–12)**
-   - Add task scheduling with configurable intervals and implement logging/backoff/security hardening.
-3. **Docs & Deployment Config (Phase 13)**
+2. **Docs & Deployment Config (Phase 13)**
    - Author comprehensive README, provide Postman/Thunder collections, and add deployment templates.
 
 ## Signature

--- a/docs/IMPLEMENTATION_AND_STATUS_REPORT.md
+++ b/docs/IMPLEMENTATION_AND_STATUS_REPORT.md
@@ -15,14 +15,15 @@ Date: 2025-09-03
 - **Phase 9 – Waivers & Streamers**: Implemented Celery `waiver_shortlist` task and API endpoints for team waivers and DEF/IDP streamers with deterministic ranking tests.
 - **Phase 10 – Frontend (Next.js)**: In progress. Added Yahoo login page, leagues table, matchups, waivers, streamers, and settings pages with client-side CSV import; Node-based tests cover arithmetic, waiver mapping, and CSV parsing.
 - **Phase 11 – Scheduling**: Added Celery beat schedules for nightly projection sync, Tuesday waiver shortlist, and a configurable game-day refresh interval with unit tests.
-- **Phases 12–13**: Not started. Security hardening and deployment docs remain outstanding.
+- **Phase 12 – Security & Resilience**: Completed. Central logging masks secrets and emails, Yahoo client uses exponential backoff with jitter and snapshot support, CORS and cookie settings secured with tests.
+- **Phase 13 – Docs & Deploy Config**: Not started. Deployment documentation and configuration templates remain outstanding.
 - **Timezone Handling**: Replaced all uses of `datetime.utcnow()` with `datetime.now(datetime.UTC)` across API modules and tests.
 
 ## Production Readiness
 Phases 0–9 have passing tests and are suitable for production usage. Phase 10 frontend work has begun but is incomplete; Phase 11 scheduling is in place, while later phases remain undeveloped.
 
 ## Next Steps
-Proceed to Phases 12–13 as outlined in `docs/FOLLOWUP.md`.
+Proceed to Phase 13 as outlined in `docs/FOLLOWUP.md`.
 
 ---
 


### PR DESCRIPTION
## Summary
- mask sensitive fields and emails in logs
- backoff Yahoo API calls with jitter and snapshot responses
- secure session cookies, configurable CORS, and document retry policy

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b61229bd148323b1cd2bebf4ed60bc