### PR TITLE
chore: add audit report and tighten web config

### DIFF
--- a/Findings.md
+++ b/Findings.md
@@ -1,0 +1,10 @@
+# Findings
+
+1. **[Blocker][Web]** `apps/web/postcss.config.js:1` — CommonJS export in an ESM package causes `pnpm build` to fail.
+2. **[Major][Web]** `apps/web/lib/live.ts:3-6` — SSE client never retries or backs off, so the stream drops permanently on disconnect.
+3. **[Major][API]** `apps/api/app/waivers.py` & `apps/api/app/routers/waivers.py` — duplicate module name `waivers` triggers MyPy import collisions.
+4. **[Minor][API]** `apps/api/app/settings.py:5` — default `redis_url` uses non-TLS `redis://`; Upstash requires `rediss://`.
+5. **[Major][Worker]** `services/worker/celery_app.py:7` — Celery broker defaults to `redis://` without TLS.
+6. **[Major][CI]** `.github/workflows/ci.yml:105-119` — Web job installs with npm then runs pnpm, mixing package managers.
+7. **[Minor][Web]** `apps/web/package-lock.json` and `apps/web/pnpm-lock.yaml` coexist, leading to inconsistent dependency locks.
+8. **[Minor][Repo]** `package.json:1-6` — root Node dependencies appear unused, increasing maintenance overhead.

--- a/Fixes.patchset
+++ b/Fixes.patchset
@@ -1,0 +1,137 @@
+*** Begin Patch
+*** Update File: apps/web/next.config.js
+@@
+-/** @type {import('next').NextConfig} */
+-const nextConfig = { experimental: { serverActions: { allowedOrigins: ["*"] } } };
+-module.exports = nextConfig;
++/** @type {import('next').NextConfig} */
++const nextConfig = {
++  experimental: {
++    serverActions: {
++      allowedOrigins: ["http://localhost:3000", "https://misfits.westfam.media"],
++    },
++  },
++};
++
++export default nextConfig;
+*** End Patch
+*** Begin Patch
+*** Update File: apps/web/postcss.config.js
+@@
+-module.exports = { plugins: { tailwindcss: {}, autoprefixer: {} } };
++export default { plugins: { tailwindcss: {}, autoprefixer: {} } };
+*** End Patch
+*** Begin Patch
+*** Delete File: apps/api/app/waivers.py
+*** End Patch
+*** Begin Patch
+*** Add File: apps/api/app/waiver_service.py
++from typing import Any, Dict, List
++
++from sqlalchemy.orm import Session
++
++from .models import Player, Projection, RosterSlot
++
++
++def compute_waiver_shortlist(
++    session: Session, team_id: int, week: int, horizon: int = 1
++) -> List[Dict[str, Any]]:
++    """Rank free agents by projected improvement over the worst starter."""
++
++    roster_ids = [
++        rs.player_id
++        for rs in session.query(RosterSlot.player_id).filter_by(
++            team_id=team_id, week=week
++        )
++    ]
++    if not roster_ids:
++        return []
++
++    worst_proj = (
++        session.query(Projection.projected_points)
++        .filter(Projection.player_id.in_(roster_ids), Projection.week == week)
++        .order_by(Projection.projected_points.asc())
++        .limit(1)
++        .scalar()
++    )
++    if worst_proj is None:
++        return []
++
++    candidates = (
++        session.query(Player, Projection.projected_points)
++        .join(Projection, (Player.id == Projection.player_id) & (Projection.week == week))
++        .filter(~Player.id.in_(roster_ids))
++        .all()
++    )
++
++    results: List[Dict[str, Any]] = []
++    acquisition_prob = max(0.0, 1.0 - 0.1 * (horizon - 1))
++    for player, proj in candidates:
++        results.append(
++            {
++                "player_id": player.id,
++                "name": player.name,
++                "projected_points": proj,
++                "delta": proj - worst_proj,
++                "acquisition_prob": acquisition_prob,
++            }
++        )
++
++    results.sort(key=lambda x: x["delta"], reverse=True)
++    return results
+*** End Patch
+*** Begin Patch
+*** Update File: apps/api/app/routers/waivers.py
+@@
+-from ..waivers import compute_waiver_shortlist
++from ..waiver_service import compute_waiver_shortlist
+*** End Patch
+*** Begin Patch
+*** Update File: services/worker/tasks.py
+@@
+-from app.waivers import compute_waiver_shortlist  # type: ignore  # noqa: E402
++from app.waiver_service import compute_waiver_shortlist  # type: ignore  # noqa: E402
+*** End Patch
+*** Begin Patch
+*** Update File: apps/api/app/settings.py
+@@
+-    redis_url: str = "redis://redis:6379/0"
++    redis_url: str = "rediss://redis:6379/0"
+*** End Patch
+*** Begin Patch
+*** Update File: services/worker/celery_app.py
+@@
+-BROKER = os.getenv("REDIS_URL", "redis://redis:6379/0")
++BROKER = os.getenv("REDIS_URL", "rediss://redis:6379/0")
+*** End Patch
+*** Begin Patch
+*** Update File: .github/workflows/ci.yml
+@@
+-      - name: Install dependencies
+-        run: |
+-          cd apps/web
+-          npm ci
+-          npm install -g pnpm
++      - name: Install dependencies
++        run: |
++          cd apps/web
++          pnpm install
+@@
+-      - name: Lint with pnpm
+-        run: |
+-          cd apps/web
+-          pnpm lint
++      - name: Lint
++        run: |
++          cd apps/web
++          pnpm lint
+@@
+-      - name: Build with pnpm
+-        run: |
+-          cd apps/web
+-          pnpm build
++      - name: Build
++        run: |
++          cd apps/web
++          pnpm build
+*** End Patch

--- a/Incorrect-or-Incomplete.md
+++ b/Incorrect-or-Incomplete.md
@@ -1,0 +1,10 @@
+# Incorrect or Incomplete Items
+
+- `apps/web/postcss.config.js:1` — uses CommonJS `module.exports` in an ESM project; Next.js build fails.
+- `apps/web/lib/live.ts:3-6` — SSE subscription lacks reconnection/backoff logic.
+- `apps/api/app/waivers.py:1-40` & `apps/api/app/routers/waivers.py:1-20` — duplicate module names (`waivers`) produce MyPy error: "Duplicate module named 'waivers'".
+- `apps/api/app/settings.py:5` — default `redis_url` uses `redis://` instead of required TLS `rediss://`.
+- `services/worker/celery_app.py:7` — `REDIS_URL` fallback uses non-TLS `redis://redis:6379/0`.
+- `.github/workflows/ci.yml:105-119` — web CI step mixes `npm ci` with `pnpm lint`/`pnpm build`.
+- `apps/web/package-lock.json` vs `apps/web/pnpm-lock.yaml` — multiple lockfiles tracked.
+- `package.json:1-6` — root dependencies (`dotenv`, `pg`) unused by workspace.

--- a/PR-Plan.md
+++ b/PR-Plan.md
@@ -1,0 +1,17 @@
+# PR Plan
+
+1. **PR-1: Web build configuration**
+   - Fix ESM exports for Next and PostCSS configs; remove redundant lockfile.
+   - Tests: `pnpm lint`, `pnpm build`.
+
+2. **PR-2: API waiver module cleanup**
+   - Rename `waivers.py` to `waiver_service.py` and update imports to resolve MyPy collisions.
+   - Tests: `ruff check`, `black --check`, `mypy app/`, `pytest`.
+
+3. **PR-3: Enforce TLS defaults**
+   - Update `redis_url` defaults in API and worker to `rediss://`; document in `.env.example`.
+   - Tests: `ruff check` for API and worker.
+
+4. **PR-4: CI and dependency hygiene**
+   - Use `pnpm install` in web CI job and drop unused root `package.json`/lockfiles.
+   - Tests: GitHub Actions workflow run on PR.

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,3 +1,10 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = { experimental: { serverActions: { allowedOrigins: ["*"] } } };
-module.exports = nextConfig;
+const nextConfig = {
+  experimental: {
+    serverActions: {
+      allowedOrigins: ["http://localhost:3000", "https://misfits.westfam.media"],
+    },
+  },
+};
+
+export default nextConfig;


### PR DESCRIPTION
## Summary
- restrict Next.js server actions to known domains
- document audit findings and remediation plan

## Testing
- `ruff check .` *(apps/api)*
- `black --check .` *(apps/api) **failed***
- `mypy app/` *(apps/api) **failed***
- `pytest` *(apps/api)*
- `ruff check .` *(services/worker)*
- `black --check .` *(services/worker) **failed***
- `mypy tasks.py` *(services/worker) **failed***
- `pytest` *(services/worker)*
- `pnpm lint` *(apps/web)*
- `pnpm build` *(apps/web) **failed***

------
https://chatgpt.com/codex/tasks/task_e_68b669abec508323bc484a521560eb53