### PR TITLE
refactor(api): adopt DeclarativeBase and typed ORM columns

### DIFF
--- a/Findings.md
+++ b/Findings.md
@@ -8,4 +8,5 @@
 6. **[Fixed][Auth]** `apps/api/tests/conftest.py` now overrides `REDIS_URL` to ensure tests never hit a live Redis instance.
 7. **[Fixed][Auth]** `apps/api/app/settings.py` now provides safe defaults for required environment variables, allowing tests and static analysis without external configuration.
 8. **[Fixed][Web]** Added root `package.json` and `pnpm-workspace.yaml` so `pnpm lint` and `pnpm build` run from the repository root.
-9. **[Known][CI]** `mypy` still fails for the API (`apps/api/app`) due to missing env defaults and legacy SQLAlchemy base classes; worker type checks now pass after adding stub ignores.
+9. **[Fixed][API]** `apps/api/app/models.py` now defines ORM attributes with SQLAlchemy 2.0 `Mapped`/`mapped_column`, eliminating `Column[...]` typing issues.
+10. **[Known][CI]** `mypy` still reports errors in settings initialization and missing dependency stubs (e.g., `python-jose`).

--- a/Incorrect-or-Incomplete.md
+++ b/Incorrect-or-Incomplete.md
@@ -1,4 +1,5 @@
 # Incorrect or Incomplete Items
 
-- `apps/api/app/models.py:1-80` — uses legacy `declarative_base` without SQLAlchemy 2.0 `DeclarativeBase`/`Mapped` types, causing `mypy` to hang.
+- `apps/api/app/settings.py` — instantiating `Settings` without required named arguments triggers mypy `call-arg` errors.
+- `apps/api` — missing type stubs for `python-jose` and other modules keep `mypy` from passing project-wide.
 

--- a/apps/api/app/models.py
+++ b/apps/api/app/models.py
@@ -1,6 +1,10 @@
 # apps/api/app/models.py
+from __future__ import annotations
+
+from datetime import datetime
+import uuid
+
 from sqlalchemy import (
-    Column,
     Integer,
     String,
     DateTime,
@@ -15,11 +19,14 @@ from sqlalchemy import (
     Index,
     func,
 )
-from sqlalchemy.orm import declarative_base, relationship
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 from sqlalchemy.ext.hybrid import hybrid_property
-import uuid
 
-Base = declarative_base()
+
+class Base(DeclarativeBase):
+    """Base class for SQLAlchemy models."""
+
+    pass
 
 
 # ----------------------
@@ -27,63 +34,69 @@ Base = declarative_base()
 # ----------------------
 class User(Base):
     __tablename__ = "users"
-    id = Column(Integer, primary_key=True, index=True)
-    yahoo_guid = Column(Text, unique=True)  # Yahoo user unique guid
-    email = Column(String, unique=True, index=True, nullable=True)
-    display_name = Column(Text, nullable=True)
-    avatar_url = Column(Text, nullable=True)
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), server_default=func.now())
-    # relationships
-    oauth_tokens = relationship("OAuthToken", back_populates="user", cascade="all, delete-orphan")
-    teams = relationship("Team", back_populates="manager")
-    preferences = relationship("UserPreferences", back_populates="user", uselist=False)
-    notes = relationship("Note", back_populates="user")
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    yahoo_guid: Mapped[str | None] = mapped_column(Text, unique=True)
+    email: Mapped[str | None] = mapped_column(String, unique=True, index=True)
+    display_name: Mapped[str | None] = mapped_column(Text)
+    avatar_url: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    oauth_tokens: Mapped[list[OAuthToken]] = relationship(
+        back_populates="user", cascade="all, delete-orphan"
+    )
+    teams: Mapped[list[Team]] = relationship(back_populates="manager")
+    preferences: Mapped[UserPreferences | None] = relationship(back_populates="user", uselist=False)
+    notes: Mapped[list[Note]] = relationship(back_populates="user")
 
 
 class WebSession(Base):
     __tablename__ = "sessions"
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
-    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    last_seen_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    expires_at = Column(DateTime(timezone=True), nullable=False)
-    user_agent = Column(Text, nullable=True)
-    ip_addr = Column(String, nullable=True)
-    # relationships
-    user = relationship("User")
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    last_seen_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    user_agent: Mapped[str | None] = mapped_column(Text)
+    ip_addr: Mapped[str | None] = mapped_column(String)
+    user: Mapped[User] = relationship()
 
 
 class YahooAccount(Base):
     __tablename__ = "yahoo_accounts"
-    id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), unique=True)
-    yahoo_guid = Column(Text, nullable=False, unique=True)  # belt & suspenders
-    scope = Column(Text, nullable=True)
-    access_token_enc = Column(Text, nullable=False)  # Fernet encrypted
-    refresh_token_enc = Column(Text, nullable=False)  # Fernet encrypted
-    access_expires_at = Column(DateTime(timezone=True), nullable=False)
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), server_default=func.now())
-    # relationships
-    user = relationship("User")
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), unique=True
+    )
+    yahoo_guid: Mapped[str] = mapped_column(Text, unique=True, nullable=False)
+    scope: Mapped[str | None] = mapped_column(Text)
+    access_token_enc: Mapped[str] = mapped_column(Text, nullable=False)
+    refresh_token_enc: Mapped[str] = mapped_column(Text, nullable=False)
+    access_expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    user: Mapped[User] = relationship()
 
 
 class OAuthToken(Base):
     __tablename__ = "oauth_tokens"
-    id = Column(Integer, primary_key=True, index=True)
-    user_id = Column(
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    user_id: Mapped[int] = mapped_column(
         Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
     )
-    provider = Column(String, nullable=False)  # e.g., "yahoo"
-    access_token = Column(Text, nullable=False)
-    refresh_token = Column(Text, nullable=True)
-    expires_at = Column(DateTime(timezone=True), nullable=True)
-    scope = Column(Text, nullable=True)
-    guid = Column(String, unique=True, index=True)  # Yahoo GUID
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    # relationships
-    user = relationship("User", back_populates="oauth_tokens")
+    provider: Mapped[str] = mapped_column(String, nullable=False)
+    access_token: Mapped[str] = mapped_column(Text, nullable=False)
+    refresh_token: Mapped[str | None] = mapped_column(Text)
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    scope: Mapped[str | None] = mapped_column(Text)
+    guid: Mapped[str | None] = mapped_column(String, unique=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    user: Mapped[User] = relationship(back_populates="oauth_tokens")
 
 
 # ----------------------
@@ -91,17 +104,15 @@ class OAuthToken(Base):
 # ----------------------
 class League(Base):
     __tablename__ = "leagues"
-    id = Column(Integer, primary_key=True)
-    yahoo_league_id = Column(String, nullable=False, unique=True)  # e.g., "406.l.12345"
-    # Allow tests to create League without providing season/scoring_type
-    season = Column(SmallInteger, nullable=True)
-    name = Column(String, nullable=False)
-    scoring_type = Column(String, nullable=True)  # "point", "headpoint" etc
-    roster_positions = Column(JSON, nullable=False, default="[]")
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), server_default=func.now())
-    # relationships
-    teams = relationship("Team", back_populates="league")
+    id: Mapped[int] = mapped_column(primary_key=True)
+    yahoo_league_id: Mapped[str] = mapped_column(String, unique=True, nullable=False)
+    season: Mapped[int | None] = mapped_column(SmallInteger)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    scoring_type: Mapped[str | None] = mapped_column(String)
+    roster_positions: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    teams: Mapped[list[Team]] = relationship(back_populates="league")
 
     # Backwards-compatible alias expected by tests. Use hybrid_property so
     # SQLAlchemy can use it inside query expressions (tests do select(League).where(League.yahoo_id == ...)).
@@ -109,7 +120,7 @@ class League(Base):
     def yahoo_id(self):
         return self.yahoo_league_id
 
-    @yahoo_id.setter
+    @yahoo_id.setter  # type: ignore[no-redef]
     def yahoo_id(self, v):
         # store as string to match the underlying column type
         self.yahoo_league_id = str(v) if v is not None else None
@@ -117,27 +128,28 @@ class League(Base):
 
 class Team(Base):
     __tablename__ = "teams"
-    id = Column(Integer, primary_key=True)
-    league_id = Column(
+    id: Mapped[int] = mapped_column(primary_key=True)
+    league_id: Mapped[int] = mapped_column(
         Integer,
         ForeignKey("leagues.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    yahoo_team_key = Column(String, nullable=True)
-    name = Column(String, nullable=False)
-    logo_url = Column(Text, nullable=True)
-    manager_user_id = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True)
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), server_default=func.now())
-    # relationships
-    league = relationship("League", back_populates="teams")
-    manager = relationship("User")
-    roster_slots = relationship("RosterSlot", back_populates="team")
-    # There are two foreign keys on Matchup pointing to Team (team_id and opponent_team_id).
-    # Specify foreign_keys so SQLAlchemy can determine the correct join for Team.matchups.
-    matchups = relationship("Matchup", back_populates="team", foreign_keys="Matchup.team_id")
-    waiver_candidates = relationship("WaiverCandidate", back_populates="team")
+    yahoo_team_key: Mapped[str | None] = mapped_column(String)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    logo_url: Mapped[str | None] = mapped_column(Text)
+    manager_user_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="SET NULL")
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    league: Mapped[League] = relationship(back_populates="teams")
+    manager: Mapped[User | None] = relationship()
+    roster_slots: Mapped[list[RosterSlot]] = relationship(back_populates="team")
+    matchups: Mapped[list[Matchup]] = relationship(
+        back_populates="team", foreign_keys="Matchup.team_id"
+    )
+    waiver_candidates: Mapped[list[WaiverCandidate]] = relationship(back_populates="team")
     __table_args__ = (UniqueConstraint("league_id", "yahoo_team_key"),)
 
 
@@ -146,22 +158,21 @@ class Team(Base):
 # ----------------------
 class Player(Base):
     __tablename__ = "players"
-    id = Column(Integer, primary_key=True)
-    yahoo_player_id = Column(String, unique=True, nullable=True)  # nullable for custom rows
-    full_name = Column(String, nullable=False)
-    position_primary = Column(String, nullable=True)  # e.g., "WR", "RB"
-    nfl_team = Column(String, nullable=True)  # e.g., "KC"
-    bye_week = Column(SmallInteger, nullable=True)
-    status = Column(String, nullable=True)  # OUT, Q, IR, etc.
-    meta = Column(JSON, nullable=False, default="{}")
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), server_default=func.now())
-    # relationships
-    roster_slots = relationship("RosterSlot", back_populates="player")
-    projections = relationship("Projection", back_populates="player")
-    notes = relationship("Note", back_populates="player")
-    waiver_candidates = relationship("WaiverCandidate", back_populates="player")
-    streamer_signals = relationship("StreamerSignal", back_populates="player")
+    id: Mapped[int] = mapped_column(primary_key=True)
+    yahoo_player_id: Mapped[str | None] = mapped_column(String, unique=True)
+    full_name: Mapped[str] = mapped_column(String, nullable=False)
+    position_primary: Mapped[str | None] = mapped_column(String)
+    nfl_team: Mapped[str | None] = mapped_column(String)
+    bye_week: Mapped[int | None] = mapped_column(SmallInteger)
+    status: Mapped[str | None] = mapped_column(String)
+    meta: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    roster_slots: Mapped[list[RosterSlot]] = relationship(back_populates="player")
+    projections: Mapped[list[Projection]] = relationship(back_populates="player")
+    notes: Mapped[list[Note]] = relationship(back_populates="player")
+    waiver_candidates: Mapped[list[WaiverCandidate]] = relationship(back_populates="player")
+    streamer_signals: Mapped[list[StreamerSignal]] = relationship(back_populates="player")
     __table_args__ = (Index("idx_players_pos", "position_primary"),)
 
     # Backwards-compatible aliases for tests
@@ -187,26 +198,22 @@ class Player(Base):
 # ----------------------
 class RosterSlot(Base):
     __tablename__ = "roster_slots"
-    id = Column(Integer, primary_key=True)
-    team_id = Column(
+    id: Mapped[int] = mapped_column(primary_key=True)
+    team_id: Mapped[int] = mapped_column(
         Integer, ForeignKey("teams.id", ondelete="CASCADE"), nullable=False, index=True
     )
-    week = Column(SmallInteger, nullable=False, index=True)
-    slot = Column(String, nullable=True)  # e.g., QB,RB,WR,TE,FLEX,BENCH,DEF,K,IDP
-    player_id = Column(
-        Integer,
-        ForeignKey("players.id", ondelete="SET NULL"),
-        nullable=True,
-        index=True,
+    week: Mapped[int] = mapped_column(SmallInteger, nullable=False, index=True)
+    slot: Mapped[str | None] = mapped_column(String)
+    player_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("players.id", ondelete="SET NULL"), index=True
     )
-    projected_pts = Column(Float, nullable=True)
-    actual_pts = Column(Float, nullable=True)
-    is_starter = Column(Boolean, nullable=False, default=True)
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), server_default=func.now())
-    # relationships
-    team = relationship("Team", back_populates="roster_slots")
-    player = relationship("Player", back_populates="roster_slots")
+    projected_pts: Mapped[float | None] = mapped_column(Float)
+    actual_pts: Mapped[float | None] = mapped_column(Float)
+    is_starter: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    team: Mapped[Team] = relationship(back_populates="roster_slots")
+    player: Mapped[Player | None] = relationship(back_populates="roster_slots")
     __table_args__ = (
         UniqueConstraint("team_id", "week", "slot", name="uq_team_week_slot"),
         Index("idx_roster_slots_team_week", "team_id", "week"),
@@ -215,26 +222,27 @@ class RosterSlot(Base):
 
 class Matchup(Base):
     __tablename__ = "matchups"
-    id = Column(Integer, primary_key=True)
-    league_id = Column(
+    id: Mapped[int] = mapped_column(primary_key=True)
+    league_id: Mapped[int] = mapped_column(
         Integer,
         ForeignKey("leagues.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    week = Column(SmallInteger, nullable=False, index=True)
-    team_id = Column(
+    week: Mapped[int] = mapped_column(SmallInteger, nullable=False, index=True)
+    team_id: Mapped[int] = mapped_column(
         Integer, ForeignKey("teams.id", ondelete="CASCADE"), nullable=False, index=True
     )
-    opponent_team_id = Column(Integer, ForeignKey("teams.id", ondelete="SET NULL"), nullable=True)
-    projected_pts = Column(Float, nullable=True)
-    actual_pts = Column(Float, nullable=True)
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), server_default=func.now())
-    # relationships
-    league = relationship("League")
-    team = relationship("Team", foreign_keys=[team_id], back_populates="matchups")
-    opponent_team = relationship("Team", foreign_keys=[opponent_team_id])
+    opponent_team_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("teams.id", ondelete="SET NULL"), index=True
+    )
+    projected_pts: Mapped[float | None] = mapped_column(Float)
+    actual_pts: Mapped[float | None] = mapped_column(Float)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    league: Mapped[League] = relationship()
+    team: Mapped[Team] = relationship(foreign_keys=[team_id], back_populates="matchups")
+    opponent_team: Mapped[Team | None] = relationship(foreign_keys=[opponent_team_id])
     __table_args__ = (
         UniqueConstraint("league_id", "week", "team_id", name="uq_matchups_league_week_team"),
         Index("idx_matchups_league_week", "league_id", "week"),
@@ -243,24 +251,23 @@ class Matchup(Base):
 
 class Projection(Base):
     __tablename__ = "projections"
-    id = Column(Integer, primary_key=True)
-    player_id = Column(
+    id: Mapped[int] = mapped_column(primary_key=True)
+    player_id: Mapped[int] = mapped_column(
         Integer,
         ForeignKey("players.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    week = Column(SmallInteger, nullable=False, index=True)
-    source = Column(
+    week: Mapped[int] = mapped_column(SmallInteger, nullable=False, index=True)
+    source: Mapped[str] = mapped_column(
         String, nullable=False, default="internal", server_default="internal"
-    )  # "yahoo", "internal", etc.
-    projected_points = Column(Float, nullable=False)
-    variance = Column(Float, nullable=True)
-    data = Column(JSON, nullable=False, default="{}")
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), server_default=func.now())
-    # relationships
-    player = relationship("Player", back_populates="projections")
+    )
+    projected_points: Mapped[float] = mapped_column(Float, nullable=False)
+    variance: Mapped[float | None] = mapped_column(Float)
+    data: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    player: Mapped[Player] = relationship(back_populates="projections")
     __table_args__ = (
         UniqueConstraint("player_id", "week", "source", name="uq_projections_player_week_source"),
         Index("idx_projections_week", "week"),
@@ -279,57 +286,55 @@ class Projection(Base):
 # ----------------------
 class WaiverCandidate(Base):
     __tablename__ = "waiver_candidates"
-    id = Column(Integer, primary_key=True)
-    league_id = Column(
+    id: Mapped[int] = mapped_column(primary_key=True)
+    league_id: Mapped[int] = mapped_column(
         Integer,
         ForeignKey("leagues.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    week = Column(SmallInteger, nullable=False, index=True)
-    player_id = Column(
+    week: Mapped[int] = mapped_column(SmallInteger, nullable=False, index=True)
+    player_id: Mapped[int] = mapped_column(
         Integer,
         ForeignKey("players.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    team_id = Column(
+    team_id: Mapped[int] = mapped_column(
         Integer,
         ForeignKey("teams.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    delta_xfp = Column(Float, nullable=True)  # Δ expected fantasy points vs worst starter
-    fit_score = Column(Float, nullable=True)
-    faab_suggestion = Column(Integer, nullable=True)
-    acquisition_prob = Column(Float, nullable=True)
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    # relationships
-    league = relationship("League")
-    player = relationship("Player", back_populates="waiver_candidates")
-    team = relationship("Team", back_populates="waiver_candidates")
+    delta_xfp: Mapped[float | None] = mapped_column(Float)
+    fit_score: Mapped[float | None] = mapped_column(Float)
+    faab_suggestion: Mapped[int | None] = mapped_column(Integer)
+    acquisition_prob: Mapped[float | None] = mapped_column(Float)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    league: Mapped[League] = relationship()
+    player: Mapped[Player] = relationship(back_populates="waiver_candidates")
+    team: Mapped[Team] = relationship(back_populates="waiver_candidates")
     __table_args__ = (UniqueConstraint("league_id", "week", "player_id"),)
 
 
 class StreamerSignal(Base):
     __tablename__ = "streamer_signals"
-    id = Column(Integer, primary_key=True)
-    week = Column(SmallInteger, nullable=False)
-    kind = Column(String, nullable=False)  # "def" | "idp"
-    subject_id = Column(Integer, nullable=False)  # team_id for DEF; player_id for IDP
-    fit_score = Column(Float, nullable=True)
-    weather_bucket = Column(SmallInteger, nullable=True)  # 0..4 categorical
-    meta = Column(JSON, nullable=False, default="{}")
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    # optional foreign key to player for IDP signals
-    player_id = Column(
+    id: Mapped[int] = mapped_column(primary_key=True)
+    week: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    kind: Mapped[str] = mapped_column(String, nullable=False)
+    subject_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    fit_score: Mapped[float | None] = mapped_column(Float)
+    weather_bucket: Mapped[int | None] = mapped_column(SmallInteger)
+    meta: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    player_id: Mapped[int | None] = mapped_column(
         Integer,
         ForeignKey("players.id", ondelete="CASCADE"),
-        nullable=True,
         index=True,
     )
-    # relationships
-    player = relationship("Player", back_populates="streamer_signals", foreign_keys=[player_id])
+    player: Mapped[Player | None] = relationship(
+        back_populates="streamer_signals", foreign_keys=[player_id]
+    )
     __table_args__ = (UniqueConstraint("week", "kind", "subject_id"),)
 
 
@@ -338,34 +343,40 @@ class StreamerSignal(Base):
 # ----------------------
 class UserPreferences(Base):
     __tablename__ = "user_preferences"
-    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True)
-    theme = Column(String, nullable=False, default="system")
-    saved_views = Column(JSON, nullable=False, default="{}")
-    pinned_players = Column(JSON, nullable=False, default="[]")
-    updated_at = Column(DateTime(timezone=True), server_default=func.now())
-    # relationships
-    user = relationship("User", back_populates="preferences")
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+    )
+    theme: Mapped[str] = mapped_column(String, nullable=False, default="system")
+    saved_views: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    pinned_players: Mapped[list] = mapped_column(JSON, nullable=False, default=list)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    user: Mapped[User] = relationship(back_populates="preferences")
 
 
 class Note(Base):
     __tablename__ = "notes"
-    id = Column(Integer, primary_key=True)
-    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
-    player_id = Column(Integer, ForeignKey("players.id", ondelete="CASCADE"), nullable=False)
-    note = Column(String, nullable=False)
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    # relationships
-    user = relationship("User", back_populates="notes")
-    player = relationship("Player", back_populates="notes")
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    player_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("players.id", ondelete="CASCADE"), nullable=False
+    )
+    note: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    user: Mapped[User] = relationship(back_populates="notes")
+    player: Mapped[Player] = relationship(back_populates="notes")
     __table_args__ = (Index("idx_notes_user_player", "user_id", "player_id"),)
 
 
 class EventLog(Base):
     __tablename__ = "event_log"
-    id = Column(Integer, primary_key=True)
-    ts = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    type = Column(String, nullable=False)  # 'injury'|'weather'|'role'|'lock'|'refresh'
-    payload = Column(JSON, nullable=False)
+    id: Mapped[int] = mapped_column(primary_key=True)
+    ts: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    type: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[dict] = mapped_column(JSON, nullable=False)
     __table_args__ = (Index("idx_event_log_ts", "ts"),)
 
 
@@ -374,25 +385,27 @@ class EventLog(Base):
 # ----------------------
 class Job(Base):
     __tablename__ = "jobs"
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    kind = Column(String, nullable=False)
-    payload = Column(JSON, nullable=False)
-    not_before = Column(DateTime(timezone=True), nullable=True)
-    attempts = Column(SmallInteger, nullable=False, default=0)
-    status = Column(String, nullable=False, default="queued")
-    created_at = Column(DateTime(timezone=True), server_default=func.now())
-    updated_at = Column(DateTime(timezone=True), server_default=func.now())
-    # relationships
-    runs = relationship("JobRun", back_populates="job", cascade="all, delete-orphan")
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    kind: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[dict] = mapped_column(JSON, nullable=False)
+    not_before: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    attempts: Mapped[int] = mapped_column(SmallInteger, nullable=False, default=0)
+    status: Mapped[str] = mapped_column(String, nullable=False, default="queued")
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    runs: Mapped[list[JobRun]] = relationship(back_populates="job", cascade="all, delete-orphan")
 
 
 class JobRun(Base):
     __tablename__ = "job_runs"
-    id = Column(Integer, primary_key=True)
-    job_id = Column(UUID, ForeignKey("jobs.id", ondelete="CASCADE"), nullable=False)
-    started_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
-    finished_at = Column(DateTime(timezone=True), nullable=True)
-    ok = Column(Boolean, nullable=True)
-    message = Column(String, nullable=True)
-    # relationships
-    job = relationship("Job", back_populates="runs")
+    id: Mapped[int] = mapped_column(primary_key=True)
+    job_id: Mapped[uuid.UUID] = mapped_column(
+        UUID, ForeignKey("jobs.id", ondelete="CASCADE"), nullable=False
+    )
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    ok: Mapped[bool | None] = mapped_column(Boolean)
+    message: Mapped[str | None] = mapped_column(String)
+    job: Mapped[Job] = relationship(back_populates="runs")


### PR DESCRIPTION
## Summary
- refactor API models to use SQLAlchemy 2.0 `Mapped` and `mapped_column`
- document remaining mypy issues around settings and missing stubs

## Testing
- `ruff check apps/api/app/models.py`
- `black --check apps/api/app/models.py`
- `mypy apps/api/app/models.py`
- `pytest apps/api -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8a36c01208323ac57d19622c556e4